### PR TITLE
add 'cpu_usage is null' message to debug instead of warning

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -142,7 +142,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
         // TODO if requested more than used, this is not taken into account, right?
         Double cpu_usage = trace.get('%cpu') as Double
         if ( cpu_usage == null ) {
-            log.warn "cpu_usage is null"
+            log.debug "cpu_usage is null"
             // TODO why is value null, because task was finished so fast that it was not captured? Or are there other reasons?
             // Assuming requested cpus were used with 100%
             cpu_usage = nc * 100


### PR DESCRIPTION
This message is printed for every task, polluting the pipeline execution output in the terminal. Here I print them as a debug message instead. The message will be printed to `.nextflow.log`