### PR TITLE
remove redundant information from output report

### DIFF
--- a/plugins/nf-co2footprint/src/resources/CO2FootprintReportTemplate.html
+++ b/plugins/nf-co2footprint/src/resources/CO2FootprintReportTemplate.html
@@ -142,61 +142,11 @@
           (<span id="completed_fromnow"></span>duration: <strong>${workflow.duration}</strong>)
         </dd>
 
-        <dl>
-          <div class="progress" style="height: 1.6rem; margin: 1.2rem auto; border-radius: 0.20rem;">
-            <div style="width: ${workflow.stats.succeedPct}%" class="progress-bar bg-success" data-toggle="tooltip" data-placement="top" title="$workflow.stats.succeedCount tasks succeeded"><span class="text-truncate">&nbsp; $workflow.stats.succeedCount succeeded &nbsp;</span></div>
-            <div style="width: ${workflow.stats.cachedPct}%" class="progress-bar bg-secondary" data-toggle="tooltip" data-placement="top" title="$workflow.stats.cachedCount tasks were cached"><span class="text-truncate">&nbsp; $workflow.stats.cachedCount cached &nbsp;</span></div>
-            <div style="width: ${workflow.stats.ignoredPct}%" class="progress-bar bg-warning" data-toggle="tooltip" data-placement="top" title="$workflow.stats.ignoredCount tasks reported and error and were ignored"><span class="text-truncate">&nbsp; $workflow.stats.ignoredCount ignored &nbsp;</span></div>
-            <div style="width: ${workflow.stats.failedPct}%" class="progress-bar bg-danger" data-toggle="tooltip" data-placement="top" title="$workflow.stats.failedCount tasks failed"><span class="text-truncate">&nbsp; $workflow.stats.failedCount failed &nbsp;</span></div>
-          </div>
-        </dl>
-
         <dt>Nextflow command</dt>
         <dd><pre class="nfcommand"><code>${workflow.commandLine}</code></pre></dd>
       </dl>
 
       <dl class="row small">
-        <dt class="col-sm-3">CPU-Hours</dt>
-        <dd class="col-sm-9"><samp>${workflow.stats.computeTimeFmt}</samp></dd>
-
-        <dt class="col-sm-3">Launch directory</dt>
-        <dd class="col-sm-9"><samp>${workflow.launchDir}</samp></dd>
-
-        <dt class="col-sm-3">Work directory</dt>
-        <dd class="col-sm-9"><samp>${workflow.workDir.toUriString()}</samp></dd>
-
-        <dt class="col-sm-3">Project directory</dt>
-        <dd class="col-sm-9"><samp>${workflow.projectDir}</samp></dd>
-
-        <% if (workflow.scriptName) { %>
-          <dt class="col-sm-3">Script name</dt>
-          <dd class="col-sm-9"><samp>${workflow.scriptName}</samp></dd>
-        <% } %>
-
-        <% if (workflow.scriptId) { %>
-          <dt class="col-sm-3">Script ID</dt>
-          <dd class="col-sm-9"><code>${workflow.scriptId}</code></dd>
-        <% } %>
-
-        <dt class="col-sm-3">Workflow session</dt>
-        <dd class="col-sm-9"><code>${workflow.sessionId}</code></dd>
-
-        <% if (workflow.repository) { %>
-          <dt class="col-sm-3">Workflow repository</dt>
-          <dd class="col-sm-9"><code>${workflow.repository}</code>, revision <code>${workflow.revision}</code> (commit hash <code>${workflow.commitId}</code>)</dd>
-        <% } %>
-
-        <dt class="col-sm-3">Workflow profile</dt>
-        <dd class="col-sm-9">${workflow.profile}</dd>
-
-        <% if (workflow.container) { %>
-        <dt class="col-sm-3">Workflow container</dt>
-        <dd class="col-sm-9"><samp>${workflow.container}</samp></dd>
-
-        <dt class="col-sm-3">Container engine</dt>
-        <dd class="col-sm-9"><samp>${workflow.containerEngine?:'-'}</samp></dd>
-        <% } %>
-
         <dt class="col-sm-3">Nextflow version</dt>
         <dd class="col-sm-9">version ${workflow.nextflow.version}, build ${workflow.nextflow.build} (${workflow.nextflow.timestamp})</dd>
       </dl>
@@ -230,11 +180,13 @@
         <% } %>
       </dl>
 
+      <dl class="row small">
       <p>The calculation of these values is based on the carbon footprint computation method
         developed in the Green Algorithms project: www.green-algorithms.org</p>
       <p>Lannelongue, L., Grealey, J., Inouye, M.,
         Green Algorithms: Quantifying the Carbon Footprint of Computation.
         Adv. Sci. 2021, 2100707. https://doi.org/10.1002/advs.202100707</p>
+      </dl>
     </div>
   </div>
 


### PR DESCRIPTION
remove redundant information from output report, it's available in the regular NF report

![image](https://github.com/nextflow-io/nf-co2footprint/assets/8224255/8645331b-3984-4006-adaf-1263ae8beffb)
