### PR TITLE
add energy consumption plot to a tab

### DIFF
--- a/plugins/nf-co2footprint/src/resources/CO2FootprintReportTemplate.html
+++ b/plugins/nf-co2footprint/src/resources/CO2FootprintReportTemplate.html
@@ -242,11 +242,15 @@
     <h2 id="resources" style="padding-top: 80px;">CO2 Footprint Measures</h2>
     <p>These plots give an overview of the distribution of resource usage for each process.</p>
 
-    <h4>CO2e</h4>
     <ul class="nav nav-tabs" id="co2eplot_tabs" role="tablist">
       <li class="nav-item">
         <a class="nav-link active" id="co2eplot_tablink" data-toggle="tab" href="#co2eplot_tabpanel" role="tab" aria-controls="co2eplot_tabpanel" aria-expanded="false">
-          Raw Emissions
+          Raw CO2 Emissions
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="energyplot_tablink" data-toggle="tab" href="#energyplot_tabpanel" role="tab" aria-controls="energyplot_tabpanel" aria-expanded="false">
+          Raw Energy Consumption
         </a>
       </li>
     </ul>
@@ -254,25 +258,8 @@
       <div class="tab-pane fade show active" id="co2eplot_tabpanel" role="tabpanel">
         <div id="co2eplot"></div>
       </div>
-      <div class="tab-pane fade" id="pctco2eplot_tabpanel" role="tabpanel">
-        <div id="pctco2eplot"></div>
-      </div>
-    </div>
-
-    <h4>Energy consumption</h4>
-    <ul class="nav nav-tabs" id="energyplot_tabs" role="tablist">
-      <li class="nav-item">
-        <a class="nav-link active" id="energyplot_tablink" data-toggle="tab" href="#energyplot_tabpanel" role="tab" aria-controls="energyplot_tabpanel" aria-expanded="false">
-          Raw Consumption
-        </a>
-      </li>
-    </ul>
-    <div class="tab-content" id="energyplot_tabcontent">
-      <div class="tab-pane fade show active" id="energyplot_tabpanel" role="tabpanel">
+      <div class="tab-pane fade" id="energyplot_tabpanel" role="tabpanel">
         <div id="energyplot"></div>
-      </div>
-      <div class="tab-pane fade" id="pctenergyplot_tabpanel" role="tabpanel">
-        <div id="pctenergyplot"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
The energy consumption plot doesn't occupy the whole page space, still don't know why

<img width="1148" alt="image" src="https://github.com/nextflow-io/nf-co2footprint/assets/8224255/091de619-1428-4e3c-9cdd-aa1054d14e65">
<img width="986" alt="image" src="https://github.com/nextflow-io/nf-co2footprint/assets/8224255/0538a952-ed49-42fb-84bb-0ec235d90158">

