### PR TITLE
Add metrics to task output and html task table

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -398,7 +398,8 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     (Double) powerdrawCPU,
                     (Double) cpu_usage,
                     (Long) memory,
-                    trace.get('name').toString()
+                    trace.get('name').toString(),
+                    trace.get('cpu_model').toString()
             )
             total_energy += eConsumption
             total_co2 += co2
@@ -449,7 +450,8 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     (Double) powerdrawCPU,
                     (Double) cpu_usage,
                     (Long) memory,
-                    trace.get('name').toString()
+                    trace.get('name').toString(),
+                    trace.get('cpu_model').toString()
             )
             total_energy += eConsumption
             total_co2 += co2

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -304,6 +304,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
 
             writer.send { co2eFile.println(
                     "task_id\t"
+                    + "name\t"
                     + "energy_consumption\t"
                     + "CO2e\t"
                     + "time\t"
@@ -403,7 +404,9 @@ class CO2FootprintFactory implements TraceObserverFactory {
             // save to the file
             writer.send {
                 PrintWriter it -> it.println(
-                        "${taskId}\t${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
+                        "${taskId}\t"
+                        + "${trace.get('name').toString()}\t"
+                        + "${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
                         + "${HelperFunctions.convertToReadableUnits(co2,3)}g\t"
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
@@ -450,7 +453,9 @@ class CO2FootprintFactory implements TraceObserverFactory {
             // save to the file
             writer.send {
                 PrintWriter it -> it.println(
-                        "${taskId}\t${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
+                        "${taskId}\t"
+                        + "${trace.get('name').toString()}\t"
+                        + "${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
                         + "${HelperFunctions.convertToReadableUnits(co2,3)}g\t"
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -305,6 +305,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
             writer.send { co2eFile.println(
                     "task_id\t"
                     + "name\t"
+                    + "status\t"
                     + "energy_consumption\t"
                     + "CO2e\t"
                     + "time\t"
@@ -406,6 +407,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                 PrintWriter it -> it.println(
                         "${taskId}\t"
                         + "${trace.get('name').toString()}\t"
+                        + "${trace.get('status').toString()}\t"
                         + "${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
                         + "${HelperFunctions.convertToReadableUnits(co2,3)}g\t"
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
@@ -455,6 +457,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                 PrintWriter it -> it.println(
                         "${taskId}\t"
                         + "${trace.get('name').toString()}\t"
+                        + "${trace.get('status').toString()}\t"
                         + "${HelperFunctions.convertToReadableUnits(eConsumption,3)}Wh\t"
                         + "${HelperFunctions.convertToReadableUnits(co2,3)}g\t"
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -311,6 +311,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     + "time\t"
                     + "cpus\t"
                     + "powerdraw_cpu\t"
+                    + "cpu_model\t"
                     + "cpu_usage\t"
                     + "requested_memory"
                 ); co2eFile.flush()
@@ -413,6 +414,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
+                        + "${trace.get('cpu_model').toString()}\t"
                         + "${cpu_usage}\t"
                         + "${HelperFunctions.convertBytesToReadableUnits(memory)}"
                 );
@@ -463,6 +465,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
+                        + "${trace.get('cpu_model').toString()}\t"
                         + "${cpu_usage}\t"
                         + "${HelperFunctions.convertBytesToReadableUnits(memory)}"
                 );

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
@@ -24,9 +24,10 @@ class CO2Record extends TraceRecord {
     private Double cpuUsage
     private Long memory
     private String name
+    private String cpu_model
     // final? or something? to make sure for key value can be set only once?
 
-    CO2Record(Double energy, Double co2e, Double time, Integer cpus, Double powerdrawCPU, Double cpuUsage, Long memory, String name) {
+    CO2Record(Double energy, Double co2e, Double time, Integer cpus, Double powerdrawCPU, Double cpuUsage, Long memory, String name, String cpu_model) {
         this.energy = energy
         this.co2e = co2e
         this.time = time
@@ -35,6 +36,7 @@ class CO2Record extends TraceRecord {
         this.cpuUsage = cpuUsage
         this.memory = memory
         this.name = name
+        this.cpu_model = cpu_model
         this.store = new LinkedHashMap<>([
                 'energy':           energy,
                 'co2e':             co2e,
@@ -43,7 +45,8 @@ class CO2Record extends TraceRecord {
                 'powerdrawCPU':     powerdrawCPU,
                 'cpuUsage':         cpuUsage,
                 'memory':           memory,
-                'name':             name
+                'name':             name,
+                'cpu_model':        cpu_model
         ])
     }
 
@@ -55,7 +58,8 @@ class CO2Record extends TraceRecord {
         powerdrawCPU:   'num',
         cpuUsage:       'num',
         memory:         'num',
-        name:           'str'
+        name:           'str',
+        cpu_model:      'str'
     ]
 
     // TODO implement accordingly to TraceRecord

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
@@ -85,9 +85,9 @@ class CO2Record extends TraceRecord {
         result.deleteCharAt(result.length() - 1); // remove the last character "}"
         result << ','
         for( int i=0; i<fields.size(); i++ ) {
-            if( i ) result << ','
             String name = fields[i]
             if ( name == 'name' ) continue // skip the name field (it's already in the key)
+            if ( i ) result << ','
             String format = i<formats?.size() ? formats[i] : null
             String value = StringEscapeUtils.escapeJavaScript(getFmtStr(name, format) ?: NA)
             result << QUOTE << name << QUOTE << ":" << QUOTE << value << QUOTE

--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
@@ -255,6 +255,7 @@ $(function() {
           { title: 'Power draw of a computing core', data: 'powerdrawCPU' },
           { title: 'Core usage factor', data: 'cpuUsage' },
           { title: 'Memory', data: 'memory', render: make_memory },
+          { title: 'CPU model', data: 'cpu_model' },
         ],
         "deferRender": true,
         "lengthMenu": [[25, 50, 100, -1], [25, 50, 100, "All"]],


### PR DESCRIPTION
- added task `name`, `status` and `cpu_model` to txt task output
- added `cpu_model` to `CO2Record`
- fixed formatting: due to placement of `,`, `FIELDS` entries after `name` caused an error in the html output, because two `,`s. 
- added `cpu_model` to HTML report task table