### PR TITLE
Allow custom CPU TDP input file

### DIFF
--- a/docs/usage/parameters.md
+++ b/docs/usage/parameters.md
@@ -34,3 +34,7 @@ You can find the available data [here](../../plugins/nf-co2footprint/src/resourc
 Mutually exclusive with the `ci` parameter.
 - `pue`: power usage effectiveness, efficiency coefficient of the data centre.
 - `powerdrawMem`: power draw from memory.
+- `customCpuTdpFile`: Input CSV file containing custom CPU TDP data.
+This should contain the following columns: `model`,`TDP`,`n_cores`,`TDP_per_core`.
+Note that this overwrites TDP values for already provided CPU models.
+You can find the by default used TDP data [here](../../plugins/nf-co2footprint/src/resources/TDP_cpu.v2.2.csv).

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -74,9 +74,10 @@ class CO2FootprintFactory implements TraceObserverFactory {
 
     @Override
     Collection<TraceObserver> create(Session session) {
-        this.session = session
-        this.config = new CO2FootprintConfig(session.config.navigate('co2footprint') as Map)
         loadCpuTdpData(this.cpuData)
+
+        this.session = session
+        this.config = new CO2FootprintConfig(session.config.navigate('co2footprint') as Map, this.cpuData)
 
         final result = new ArrayList(2)
         // Generate CO2 footprint text output files


### PR DESCRIPTION
Allow custom CPU TDP input file and added description to docs.

I decided in the end to allow for a CSV file, since with this it maybe easier to collect the data for some use cases.