### PR TITLE
Add warning if cpu model not found

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -114,6 +114,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
             }
             c++
         }
+        log.warn "Could not find CPU model ${cpu_model} in given TDP data. Using default CPU power draw value!"
         return cpuData['default']
     }
 


### PR DESCRIPTION
Add warning if cpu model not found in given CPU TDP data to inform user that the default power draw value is used. 

