### PR TITLE
Add parameter to ignore cpu_model and to change default CPU power draw value

### DIFF
--- a/docs/usage/parameters.md
+++ b/docs/usage/parameters.md
@@ -39,3 +39,5 @@ Mutually exclusive with the `ci` parameter.
 This should contain the following columns: `model`,`TDP`,`n_cores`,`TDP_per_core`.
 Note that this overwrites TDP values for already provided CPU models.
 You can find the by default used TDP data [here](../../plugins/nf-co2footprint/src/resources/TDP_cpu.v2.2.csv).
+- `ignoreCpuModel`: ignore the retrieved Nextflow trace `cpu_model` name and use the default CPU power draw value. This is useful, if the cpu model information provided by the linux kernel is not correct, for example, in the case of VMs emulating a different CPU architecture.
+- `powerdrawCpuDefault`: the default value used as the power draw from a computing core. This is only applied if the parameter `ignoreCpuModel` is set or if the retrieved `cpu_model` could not be found in the given CPU TDP data.

--- a/docs/usage/parameters.md
+++ b/docs/usage/parameters.md
@@ -39,5 +39,9 @@ Mutually exclusive with the `ci` parameter.
 This should contain the following columns: `model`,`TDP`,`n_cores`,`TDP_per_core`.
 Note that this overwrites TDP values for already provided CPU models.
 You can find the by default used TDP data [here](../../plugins/nf-co2footprint/src/resources/TDP_cpu.v2.2.csv).
-- `ignoreCpuModel`: ignore the retrieved Nextflow trace `cpu_model` name and use the default CPU power draw value. This is useful, if the cpu model information provided by the linux kernel is not correct, for example, in the case of VMs emulating a different CPU architecture.
-- `powerdrawCpuDefault`: the default value used as the power draw from a computing core. This is only applied if the parameter `ignoreCpuModel` is set or if the retrieved `cpu_model` could not be found in the given CPU TDP data.
+- `ignoreCpuModel`: ignore the retrieved Nextflow trace `cpu_model` name and use the default CPU power draw value.
+This is useful, if the cpu model information provided by the linux kernel is not correct, for example, in the case of VMs emulating a different CPU architecture.
+Default: `false`.
+- `powerdrawCpuDefault`: the default value used as the power draw from a computing core.
+This is only applied if the parameter `ignoreCpuModel` is set or if the retrieved `cpu_model` could not be found in the given CPU TDP data.
+Default: 12.0.

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -35,6 +35,7 @@ class CO2FootprintConfig {
     final private Double  pue   // PUE: power usage effectiveness efficiency, coefficient of the data centre
     final private Double  powerdrawMem  // Power draw of memory [W per GB]
     final private Boolean ignoreCpuModel
+    final private Double powerdrawCpuDefault
 
     // Retrieve CI value from file containing CI values for different locations
     protected Double retrieveCi(String location) {
@@ -90,6 +91,8 @@ class CO2FootprintConfig {
 
         pue = config.pue ?: 1.67
         powerdrawMem = config.powerdrawMem ?: 0.3725
+        powerdrawCpuDefault = config.powerdrawCpuDefault ?: 12.0
+        cpuData['default'] = powerdrawCpuDefault
 
         if (config.customCpuTdpFile)
             loadCustomCpuTdpData(cpuData, config.customCpuTdpFile)

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -34,6 +34,7 @@ class CO2FootprintConfig {
     final private Double  ci    // CI: carbon intensity
     final private Double  pue   // PUE: power usage effectiveness efficiency, coefficient of the data centre
     final private Double  powerdrawMem  // Power draw of memory [W per GB]
+    final private Boolean ignoreCpuModel
 
     // Retrieve CI value from file containing CI values for different locations
     protected Double retrieveCi(String location) {
@@ -75,6 +76,7 @@ class CO2FootprintConfig {
         file = config.file ?: CO2FootprintFactory.CO2FootprintTextFileObserver.DEF_FILE_NAME
         summaryFile = config.summaryFile ?: CO2FootprintFactory.CO2FootprintTextFileObserver.DEF_SUMMARY_FILE_NAME
         reportFile = config.reportFile ?: CO2FootprintFactory.CO2FootprintReportObserver.DEF_REPORT_FILE_NAME
+        ignoreCpuModel = config.ignoreCpuModel ?: false
 
         ci = 475
         if (config.ci && config.location)
@@ -96,6 +98,7 @@ class CO2FootprintConfig {
     String getFile() { file }
     String getSummaryFile() { summaryFile }
     String getReportFile() { reportFile }
+    Boolean getIgnoreCpuModel() { ignoreCpuModel }
     String getLocation() { location }
     Double getCI() { ci }
     Double getPUE() { pue }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -138,7 +138,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
         Double nc = trace.get('cpus') as Integer
 
         // Pc: power draw of a computing core  [W]
-        Double pc = getCpuCoreTdp(trace)
+        Double pc = config.getIgnoreCpuModel() ? cpuData['default'] : getCpuCoreTdp(trace)
 
         // uc: core usage factor (between 0 and 1)
         // TODO if requested more than used, this is not taken into account, right?

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -53,7 +53,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
     final private Map<TaskId,CO2Record> co2eRecords = new ConcurrentHashMap<>()
     // TODO make sure for key value can be set only once?
 
-    private Map<String, Double> cpuData = ['default': (Double) 12.0]
+    private Map<String, Double> cpuData = [:]
     Double total_energy = 0
     Double total_co2 = 0
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -313,7 +313,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     + "time\t"
                     + "cpus\t"
                     + "powerdraw_cpu\t"
-                    + "cpu_model\t"
+                    + (config.getIgnoreCpuModel()? "" : "cpu_model\t")
                     + "cpu_usage\t"
                     + "requested_memory"
                 ); co2eFile.flush()
@@ -417,7 +417,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
-                        + "${trace.get('cpu_model').toString()}\t"
+                        + (config.getIgnoreCpuModel()? "" : "${trace.get('cpu_model').toString()}\t")
                         + "${cpu_usage}\t"
                         + "${HelperFunctions.convertBytesToReadableUnits(memory)}"
                 );
@@ -469,7 +469,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
-                        + "${trace.get('cpu_model').toString()}\t"
+                        + (config.getIgnoreCpuModel()? "" : "${trace.get('cpu_model').toString()}\t")
                         + "${cpu_usage}\t"
                         + "${HelperFunctions.convertBytesToReadableUnits(memory)}"
                 );

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -304,6 +304,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
             writer = new Agent<PrintWriter>(co2eFile)
             summaryWriter = new Agent<PrintWriter>(co2eSummaryFile)
 
+            String cpu_model_string = config.getIgnoreCpuModel()? "" : "cpu_model\t"
             writer.send { co2eFile.println(
                     "task_id\t"
                     + "name\t"
@@ -313,7 +314,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     + "time\t"
                     + "cpus\t"
                     + "powerdraw_cpu\t"
-                    + (config.getIgnoreCpuModel()? "" : "cpu_model\t")
+                    + cpu_model_string
                     + "cpu_usage\t"
                     + "requested_memory"
                 ); co2eFile.flush()
@@ -401,12 +402,13 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     (Double) cpu_usage,
                     (Long) memory,
                     trace.get('name').toString(),
-                    trace.get('cpu_model').toString()
+                    config.getIgnoreCpuModel() ? "" : trace.get('cpu_model').toString()
             )
             total_energy += eConsumption
             total_co2 += co2
 
             // save to the file
+            String cpu_model_string = config.getIgnoreCpuModel()? "" : "${trace.get('cpu_model').toString()}\t"
             writer.send {
                 PrintWriter it -> it.println(
                         "${taskId}\t"
@@ -417,7 +419,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
-                        + (config.getIgnoreCpuModel()? "" : "${trace.get('cpu_model').toString()}\t")
+                        + cpu_model_string
                         + "${cpu_usage}\t"
                         + "${HelperFunctions.convertBytesToReadableUnits(memory)}"
                 );
@@ -453,12 +455,13 @@ class CO2FootprintFactory implements TraceObserverFactory {
                     (Double) cpu_usage,
                     (Long) memory,
                     trace.get('name').toString(),
-                    trace.get('cpu_model').toString()
+                    config.getIgnoreCpuModel() ? "" : trace.get('cpu_model').toString()
             )
             total_energy += eConsumption
             total_co2 += co2
 
             // save to the file
+            String cpu_model_string = config.getIgnoreCpuModel()? "" : "${trace.get('cpu_model').toString()}\t"
             writer.send {
                 PrintWriter it -> it.println(
                         "${taskId}\t"
@@ -469,7 +472,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                         + "${HelperFunctions.convertMillisecondsToReadableUnits(time)}\t"
                         + "${cpus}\t"
                         + "${powerdrawCPU}\t"
-                        + (config.getIgnoreCpuModel()? "" : "${trace.get('cpu_model').toString()}\t")
+                        + cpu_model_string
                         + "${cpu_usage}\t"
                         + "${HelperFunctions.convertBytesToReadableUnits(memory)}"
                 );


### PR DESCRIPTION
I added two parameters
- `ignoreCpuModel`: to ignore the retrieved `cpu_model` name and use the default CPU power draw value
- `powerdrawCpuDefault`: to change the default power draw value of a computing core. Used in combination with `ignoreCpuModel` or for tasks where no TDP value could be retrieved for the `cpu_model` (either because this is `null` or because there is no entry for the `cpu_model`)

Additionally, i removed the `cpu_model` column from the TXT report if `ignoreCpuModel` is set, since this would be misleading. If the `cpu_model` was not found in the TDP data and the default power draw value is used instead, the `cpu_model` column is kept (would be task specific). In this case, anyway a warning is given out already.

Probably it would make sense, if `ignoreCpuModel` is set, to remove the `cpu_model` column from the table in the HTML report as well. @mirpedrol what do you think and is this something you could add?

Addresses https://github.com/nextflow-io/nf-co2footprint/issues/58