### PR TITLE
Add info about cached processes to docs

### DIFF
--- a/docs/co2footprint.md
+++ b/docs/co2footprint.md
@@ -11,9 +11,9 @@ A CO<sub>2</sub> equivalent (CO<sub>2</sub>e) is a metric used to compare the em
 
 For this, the amounts of other gases are converted to the amount of CO<sub>2</sub> that would have the same impact on global warming (over a 100-year period).
 
-The formula used for the calculation of the carbon footprint ($C$) of one Nextflow task is:
+The formula used for the calculation of the carbon footprint ($CO_2e$) of one Nextflow task is:
 
-$C = t \cdot (n_c \cdot P_c \cdot u_c + n_m \cdot P_m) \cdot PUE \cdot CI$
+$CO_2e = t \cdot (n_c \cdot P_c \cdot u_c + n_m \cdot P_m) \cdot PUE \cdot CI$
 
 where
 

--- a/docs/co2footprint.md
+++ b/docs/co2footprint.md
@@ -11,7 +11,7 @@ A CO<sub>2</sub> equivalent (CO<sub>2</sub>e) is a metric used to compare the em
 
 For this, the amounts of other gases are converted to the amount of CO<sub>2</sub> that would have the same impact on global warming (over a 100-year period).
 
-The formula used for the calculation of the carbon footprint ($C$) is:
+The formula used for the calculation of the carbon footprint ($C$) of one Nextflow task is:
 
 $C = t \cdot (n_c \cdot P_c \cdot u_c + n_m \cdot P_m) \cdot PUE \cdot CI$
 
@@ -25,6 +25,8 @@ where
 **$P_m$** = the power draw of memory (W, per GB)<br/>
 **$PUE$** = the efficiency coefficient of the data centre<br/>
 **$CI$** = the carbon intensity of energy production, which represents the carbon footprint of producing 1 kWh of energy for a given country and energy mix
+
+For the final CO<sub>2</sub>e estimation of a pipeline run, the values of all cached and completed tasks are summed up.
 
 !!! warning
 


### PR DESCRIPTION
Added info that for the total CO2e of a pipeline all completed and cached processes are used. 

@mirpedrol Actually, I usually also use "CO<sub>2</sub>e" for the equation, in the slides at least (just realizing that it's different in the code), could we change this for the formula in the docs as well (currently using "C")?