### PR TITLE
update Makefile and add option to compile and install to the plugins directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,15 @@
 
 config ?= compileClasspath
+version ?= $(shell grep 'Plugin-Version' plugins/nf-co2footprint/src/resources/META-INF/MANIFEST.MF | awk '{ print $$2 }')
 
 ifdef module 
 mm = :${module}:
 else 
 mm = 
 endif 
+
+NXF_HOME ?= $$HOME/.nextflow
+NXF_PLUGINS_DIR ?= $(NXF_HOME)/plugins
 
 clean:
 	./gradlew clean
@@ -43,6 +47,11 @@ ifndef class
 else
 	./gradlew ${mm}test --tests ${class}
 endif
+
+install:
+	./gradlew copyPluginZip
+	rm -rf ${NXF_PLUGINS_DIR}/nf-co2footprint-${version}
+	cp -r build/plugins/nf-co2footprint-${version} ${NXF_PLUGINS_DIR}
 
 #
 # generate build zips under build/plugins

--- a/docs/contributing/setup.md
+++ b/docs/contributing/setup.md
@@ -59,6 +59,27 @@ To test with Nextflow for development purpose:
    ./launch.sh run -plugins nf-co2footprint <script/pipeline name> [pipeline params]
    ```
 
+## Alternative: Compile and install to Nextflow plugins directory
+
+!!! warning
+
+    This will install the compiled plugin code into your `$NXF_PLUGINS_DIR` directory (default: `${HOME}/.nextflow/plugins`). 
+    If the plugin version from the manifest file (`plugins/nf-co2footprint/src/resources/META-INF/MANIFEST.MF`) of the dev code matches an existing plugin, any install will be overwritten.
+
+1. Compile and install the plugin code
+
+   ```bash
+   make compile
+   make install
+   ```
+
+2. Run nextflow with this command, specifying the plugin version:
+
+   ```bash
+   nextflow run -plugins nf-co2footprint@0.4.0 <script/pipeline name> [pipeline params]
+   ```
+
+
 ## Change and preview the docs
 
 The docs are generated using [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/). To change the docs, edit the files in the [docs/](docs/) folder and run the following command to generate the docs (after installing mkdocs via `pip install mkdocs-material`):


### PR DESCRIPTION
This PR is based on the new additions to nf-validation: https://github.com/nextflow-io/nf-validation/pull/126
Implements the make install rule from [nf-prov](https://github.com/nextflow-io/nf-prov/blob/master/Makefile).
Switches to using NXF_PLUGINS_DIR as install location.