### PR TITLE
Fix uc calculation and add warning

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -160,8 +160,10 @@ class CO2FootprintFactory implements TraceObserverFactory {
             cpu_usage = nc * 100
         }
         // TODO how to handle double, Double datatypes for ceiling?
-        Double cpus_ceil = Math.ceil( cpu_usage / 100.0 as double )
-        Double uc = cpu_usage / (100.0 * cpus_ceil) as Double
+        if ( cpu_usage == 0.0 ) {
+            warnings << "The reported CPU usage is 0.0 for at last one task!"
+        }
+        Double uc = cpu_usage / (100.0 * nc) as Double
 
         /**
          * Factors of memory power usage


### PR DESCRIPTION
I got an error for a case where the reported `cpu_usage` was 0.0. 

In this context I realised that I did not use the actual number of requested CPUs `nc` to compute `uc`, but a rounded value obtained from the nextflow `cpu_usage` metric. Not sure why exactly I did that.

This caused an error when `cpu_usage` was 0.0, but it is also bad, since for the final formula the `nc` value was used, and this would cause erroneous results if those `nc` and `cpus_ceil` would differ. 

I changed it to only use `nc` now. Additionally I added a warning if `cpu_usage` is 0.0, since this might indicate that something is wrong as well. 

@mirpedrol could you double check?
