### PR TITLE
update plugin version 1.0.0-beta to 1.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 ## Features:
 - Plot co2e and energy in one plot with two axis.
 - Report nf-co2footprint version in `co2footprint_report_*.html` and `co2footprint_summary_*.txt` reports.
-- Show Plugin parameters in html and text reports
-- Show CO2 equivalences using scientific annotations in the html reports
-- Show CO2 equivalences in text reports
+- Show Plugin parameters in html and text reports.
+- Show CO2 equivalences using scientific annotations in the html reports.
+- Show CO2 equivalences in text reports.
+- Updated documentation.
 
 ## Bug Fixes:
 - Improved numbering in contribution instructions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 ## [Unreleased]
 
-### `Added`
+# Version 1.0.0-beta.1
+## Features:
+- Plot co2e and energy in one plot with two axis.
+- Report nf-co2footprint version in `co2footprint_report_*.html` and `co2footprint_summary_*.txt` reports.
+- Show Plugin parameters in html and text reports
+- Show CO2 equivalences using scientific annotations in the html reports
+- Show CO2 equivalences in text reports
 
-- [#86](https://github.com/nextflow-io/nf-co2footprint/pull/86) Report nf-co2footprint version in `co2footprint_report_*.html` and `co2footprint_summary_*.txt` reports.
-- [#87](https://github.com/nextflow-io/nf-co2footprint/pull/87) Plot co2e and energy in one plot with two axis.
+## Bug Fixes:
+- Improved numbering in contribution instructions
+- Improved sorting in html report summary
 
-## Version 1.0.0-beta
+# Version 1.0.0-beta
 
 Initial pre-release.

--- a/plugins/nf-co2footprint/src/resources/META-INF/MANIFEST.MF
+++ b/plugins/nf-co2footprint/src/resources/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Plugin-Id: nf-co2footprint
-Plugin-Version: 1.0.0-beta
+Plugin-Version: 1.0.0-beta.1
 Plugin-Class: nextflow.co2footprint.CO2FootprintPlugin
 Plugin-Provider: nextflow
 Plugin-Requires: >=24.01.0-edge


### PR DESCRIPTION
Updated plugin version from 1.0.0-beta to 1.0.0-beta.1:

**Features:**
- Plot co2e and energy in one plot with two axis.
- Report nf-co2footprint version in `co2footprint_report_*.html` and `co2footprint_summary_*.txt` reports.
- Show Plugin parameters in html and text reports.
- Show CO2 equivalences using scientific annotations in the html reports.
- Show CO2 equivalences in text reports.
- Updated documentation.

**Bug Fixes:**
- Improved numbering in contribution instructions
- Improved sorting in html report summary