### PR TITLE
Fixed: Summary file generation after workflow completion, onFlowComplete()

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -323,11 +323,9 @@ class CO2FootprintFactory implements TraceObserverFactory {
 
             // create a new trace file
             co2eTraceFile = new PrintWriter(TraceHelper.newFileWriter(co2eTracePath, overwrite, 'co2footprint'))
-            co2eSummaryFile = new PrintWriter(TraceHelper.newFileWriter(co2eSummaryPath, overwrite, 'co2footprintsummary'))
 
             // launch the agent
             traceWriter = new Agent<PrintWriter>(co2eTraceFile)
-            summaryWriter = new Agent<PrintWriter>(co2eSummaryFile)
 
             String cpu_model_string = config.getIgnoreCpuModel()? "" : "cpu_model\t"
             traceWriter.send { co2eTraceFile.println(
@@ -355,6 +353,12 @@ class CO2FootprintFactory implements TraceObserverFactory {
 
             // wait for termination and flush the agent content
             traceWriter.await()
+
+            // create a summary trace file
+            co2eSummaryFile = new PrintWriter(TraceHelper.newFileWriter(co2eSummaryPath, overwrite, 'co2footprintsummary'))
+
+            // launch the agent
+            summaryWriter = new Agent<PrintWriter>(co2eSummaryFile)
 
             co2eSummaryFile.println("Total CO2e footprint measures of this workflow run")
             co2eSummaryFile.println("CO2e emissions: ${HelperFunctions.convertToReadableUnits(total_co2,3)}g")


### PR DESCRIPTION
1. An empty Summary file was created on error as well.
2. The erorr can be reproduced by not providing the memory parameter.
3. Now, the file will be generated at **onFlowComplete**.