### PR TITLE
Fixed: Memory param and Detect Max Memory

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -37,6 +37,8 @@ import nextflow.trace.TraceObserverFactory
 import nextflow.processor.TaskId
 
 import java.util.concurrent.ConcurrentHashMap
+import java.lang.management.ManagementFactory
+import com.sun.management.OperatingSystemMXBean
 
 /**
  * Implements the CO2Footprint observer factory
@@ -150,6 +152,12 @@ class CO2FootprintFactory implements TraceObserverFactory {
         // PSF: pragmatic scaling factor -> not used here since we aim at the CO2e of one pipeline run
         // Factor 0.001 needed to convert Pc and Pm from W to kW
 
+
+        // Detect OS
+        OperatingSystemMXBean OS = { (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean() }()
+        // Total Memory
+        Double max_memory = OS.getTotalPhysicalMemorySize() as Double
+
         // t: runtime in hours
         Double realtime = trace.get('realtime') as Double
         Double t = realtime/3600000 as Double
@@ -174,7 +182,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
         }
         // TODO how to handle double, Double datatypes for ceiling?
         if ( cpu_usage == 0.0 ) {
-            warnings << "The reported CPU usage is 0.0 for at last one task!"
+            warnings << "The reported CPU usage is 0.0 for at least one task!"
         }
         Double uc = cpu_usage / (100.0 * nc) as Double
 
@@ -182,13 +190,12 @@ class CO2FootprintFactory implements TraceObserverFactory {
          * Factors of memory power usage
          */
         // nm: size of memory available [GB] -> requested memory
-        Long memory = trace.get('memory') as Long
-        if ( memory == null ) {
-            // TODO if 'memory' not set, returns null, hande somehow?
-            log.error "TraceRecord field 'memory' is not set!"
-            System.exit(1)
+        Double memory = trace.get('memory') as Double
+        if ( memory == null || trace.get('peak_rss') as Double > memory) {
+            memory = max_memory
         }
-        Double nm = memory/1000000000 as Double
+
+        Double nm = memory/(1024*1024*1024) as Double
         // TODO handle if more memory/cpus used than requested?
 
         // Pm: power draw of memory [W per GB]


### PR DESCRIPTION
1. Memory parameter is optional by default from Nextflow, thereby if the user does not set the memory then the entire RAM is available for the process to run.
2. If memory is not set then we can find the max RAM/memory available using the java libraries:
```java
// To detect the Operating system
import com.sun.management.OperatingSystemMXBean

// To find the maximum RAM
import java.lang.management.ManagementFactory

```
and then
```
OperatingSystemMXBean OS = { (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean() }()

// Total Memory
Double max_memory = OS.getTotalPhysicalMemorySize() as Double
```
Also available at [LocalPollingMonitor.groovy](https://github.com/nextflow-io/nextflow/blob/master/modules/nextflow/src/main/groovy/nextflow/processor/LocalPollingMonitor.groovy)

3. Now we can use either the user requested RAM memory or if not provided or if it exceeds the requested RAM -> max_memory

```java
Double memory = trace.get('memory') as Double
if ( memory == null || trace.get('peak_rss') as Double > memory) {
   memory = max_memory
}
```

4. We can test the same by setting in nextflow.config file
```
plugins {
  id 'nf-co2footprint'
}
process.memory = '1'
```

and running the workflow for 

```bash
nextflow run rnaseq-nf -with-docker
```
This will automatically set the Memory attribute to max_memory, since 1KB is too low for the process.
Also, the plugin is longer dependent on user defined memory parameter and will not throw any error.