### PR TITLE
ci: Bump versions of Java & Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,20 +17,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java_version: [11, 21]
+        java_version: [17, 23]
 
     steps:
       - name: Environment
         run: env | sort
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: true
 
       - name: Setup Java ${{ matrix.java_version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{matrix.java_version}}
           architecture: x64


### PR DESCRIPTION
- Changed tested versions to [supported Java versions of nextflow](https://www.nextflow.io/docs/latest/install.html)
- Incremented version of actions to latest