### PR TITLE
Fix: Fixed concurrency issue with Config Map

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -79,8 +79,8 @@ class CO2FootprintConfig {
         }
     }
 
-    CO2FootprintConfig(ConcurrentHashMap<String, Object> configMap, TDPDataMatrix cpuData){
-        configMap = configMap ? configMap.deepClone() : [:] as ConcurrentHashMap<String, Object>
+    CO2FootprintConfig(Map<String, Object> configMap, TDPDataMatrix cpuData){
+        configMap = configMap as ConcurrentHashMap<String, Object> ?: [:]
 
         // Sanity checking
         checkConfig(configMap)

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -5,6 +5,7 @@ import groovy.util.logging.Slf4j
 import nextflow.trace.TraceHelper
 
 import java.nio.file.Paths
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * This class allows model an specific configuration, extracting values from a map and converting
@@ -78,8 +79,8 @@ class CO2FootprintConfig {
         }
     }
 
-    CO2FootprintConfig(Map<String, Object> configMap, TDPDataMatrix cpuData){
-        configMap = configMap ?: [:]
+    CO2FootprintConfig(ConcurrentHashMap<String, Object> configMap, TDPDataMatrix cpuData){
+        configMap = configMap ? configMap.deepClone() : [:] as ConcurrentHashMap<String, Object>
 
         // Sanity checking
         checkConfig(configMap)
@@ -128,14 +129,14 @@ class CO2FootprintConfig {
     SortedMap<String, Object> collectInputFileOptions() {
         return [
                 "customCpuTdpFile": customCpuTdpFile
-        ] as SortedMap
+        ].sort() as SortedMap
     }
     SortedMap<String, Object> collectOutputFileOptions() {
         return [
                 "traceFile": traceFile,
                 "summaryFile": summaryFile,
                 "reportFile": reportFile
-        ] as SortedMap
+        ].sort() as SortedMap
     }
     SortedMap<String, Object> collectCO2CalcOptions() {
         return [
@@ -145,6 +146,6 @@ class CO2FootprintConfig {
                 "powerdrawMem": powerdrawMem,
                 "powerdrawCpuDefault": powerdrawCpuDefault,
                 "ignoreCpuModel": ignoreCpuModel,
-        ] as SortedMap
+        ].sort() as SortedMap
     }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -90,7 +90,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
 
         this.session = session
         this.config = new CO2FootprintConfig(
-                session.config.navigate('co2footprint') as Map,
+                session.config.navigate('co2footprint') as ConcurrentHashMap,
                 this.tdpDataMatrix
         )
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -90,7 +90,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
 
         this.session = session
         this.config = new CO2FootprintConfig(
-                session.config.navigate('co2footprint') as ConcurrentHashMap,
+                session.config.navigate('co2footprint') as Map,
                 this.tdpDataMatrix
         )
 


### PR DESCRIPTION
Fixes to `CO2FootprintConfig`

1. Defined Map as ConcurrentHashMap to handle removing elements during pass
2. Sorted output to allow `+` operation during file creation