### PR TITLE
Documentation: Expressive renaming of `HelperFunctions` and addition of Docstrings

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2EquivalencesRecord.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2EquivalencesRecord.groovy
@@ -1,6 +1,6 @@
 package nextflow.co2footprint
 
-import nextflow.co2footprint.utils.HelperFunctions
+import nextflow.co2footprint.utils.Converter
 
 class CO2EquivalencesRecord {
     private final Double carKilometers
@@ -14,18 +14,18 @@ class CO2EquivalencesRecord {
     }
 
     Double getCarKilometers() { carKilometers }
-    String getCarKilometersReadable() { HelperFunctions.convertToScientificNotation(carKilometers) }
+    String getCarKilometersReadable() { Converter.toScientificNotation(carKilometers) }
 
     Double getTreeMonths() { treeMonths }
     String getTreeMonthsReadable() {
-        HelperFunctions.convertTimeToReadableUnits(treeMonths, 'months', 's', 'years', 1, 3)
+        Converter.toReadableTimeUnits(treeMonths, 'months', 's', 'years', 1, 3)
     }
 
     Double getPlanePercent() { planePercent }
-    String getPlanePercentReadable() { HelperFunctions.convertToScientificNotation(planePercent) }
+    String getPlanePercentReadable() { Converter.toScientificNotation(planePercent) }
 
     Integer getPlaneFlights() { planePercent / 100 as Integer }
-    String getPlaneFlightsReadable() { HelperFunctions.convertToScientificNotation(this.getPlaneFlights()) }
+    String getPlaneFlightsReadable() { Converter.toScientificNotation(this.getPlaneFlights()) }
 
     List<String> getReadableEquivalences() {
         List<String> readableEquivalences = new ArrayList<String>()

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -54,8 +54,7 @@ class CO2FootprintConfig {
         def dataReader = new InputStreamReader(this.class.getResourceAsStream('/CI_aggregated.v2.2.csv'))
 
         Double localCi = 0.0
-        String line
-        while ( line = dataReader.readLine() ) {
+        for ( String line : dataReader.readLines() ) {
             def row = line.split(",")
             if (row[0] == location) {
                 localCi = row[4].toDouble()

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -18,7 +18,7 @@ package nextflow.co2footprint
 
 import nextflow.co2footprint.utils.DeduplicateMarkerFilter
 import nextflow.co2footprint.utils.Markers
-import nextflow.co2footprint.utils.HelperFunctions
+import nextflow.co2footprint.utils.Converter
 
 import groovy.text.GStringTemplateEngine
 import groovy.transform.PackageScope
@@ -223,8 +223,8 @@ class CO2FootprintFactory implements TraceObserverFactory {
             summaryWriter = new Agent<PrintWriter>(co2eSummaryFile)
 
             co2eSummaryFile.println("Total CO2e footprint measures of this workflow run")
-            co2eSummaryFile.println("CO2e emissions: ${HelperFunctions.convertToReadableUnits(total_co2,3, 'g')}")
-            co2eSummaryFile.println("Energy consumption: ${HelperFunctions.convertToReadableUnits(total_energy,3, 'Wh')}")
+            co2eSummaryFile.println("CO2e emissions: ${Converter.toReadableUnits(total_co2,3, 'g')}")
+            co2eSummaryFile.println("Energy consumption: ${Converter.toReadableUnits(total_energy,3, 'Wh')}")
 
             CO2EquivalencesRecord equivalences = co2FootprintComputer.computeCO2footprintEquivalences(total_co2)
             List<String> readableEquivalences = equivalences.getReadableEquivalences()
@@ -579,8 +579,8 @@ class CO2FootprintFactory implements TraceObserverFactory {
          */
         protected Map renderCO2TotalsJson() {
             CO2EquivalencesRecord equivalences = co2FootprintComputer.computeCO2footprintEquivalences(total_co2)
-            [ co2:HelperFunctions.convertToReadableUnits(total_co2,3),
-              energy:HelperFunctions.convertToReadableUnits(total_energy,3),
+            [ co2:Converter.toReadableUnits(total_co2,3),
+              energy:Converter.toReadableUnits(total_energy,3),
               car: equivalences.getCarKilometersReadable(),
               tree: equivalences.getTreeMonthsReadable(),
               plane_percent: equivalences.getPlanePercentReadable(),

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -223,8 +223,8 @@ class CO2FootprintFactory implements TraceObserverFactory {
             summaryWriter = new Agent<PrintWriter>(co2eSummaryFile)
 
             co2eSummaryFile.println("Total CO2e footprint measures of this workflow run")
-            co2eSummaryFile.println("CO2e emissions: ${Converter.toReadableUnits(total_co2,3, 'g')}")
-            co2eSummaryFile.println("Energy consumption: ${Converter.toReadableUnits(total_energy,3, 'Wh')}")
+            co2eSummaryFile.println("CO2e emissions: ${Converter.toReadableUnits(total_co2,'m', 'g')}")
+            co2eSummaryFile.println("Energy consumption: ${Converter.toReadableUnits(total_energy,'m', 'Wh')}")
 
             CO2EquivalencesRecord equivalences = co2FootprintComputer.computeCO2footprintEquivalences(total_co2)
             List<String> readableEquivalences = equivalences.getReadableEquivalences()
@@ -579,8 +579,8 @@ class CO2FootprintFactory implements TraceObserverFactory {
          */
         protected Map renderCO2TotalsJson() {
             CO2EquivalencesRecord equivalences = co2FootprintComputer.computeCO2footprintEquivalences(total_co2)
-            [ co2:Converter.toReadableUnits(total_co2,3),
-              energy:Converter.toReadableUnits(total_energy,3),
+            [ co2:Converter.toReadableUnits(total_co2,'m'),
+              energy:Converter.toReadableUnits(total_energy,'m'),
               car: equivalences.getCarKilometersReadable(),
               tree: equivalences.getTreeMonthsReadable(),
               plane_percent: equivalences.getPlanePercentReadable(),

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
@@ -62,10 +62,10 @@ class CO2Record extends TraceRecord {
     ]
 
     Double getEnergyConsumption() { energy }
-    String getEnergyConsumptionReadable() { Converter.toReadableUnits(energy,3, 'Wh') }
+    String getEnergyConsumptionReadable() { Converter.toReadableUnits(energy,'m', 'Wh') }
 
     Double getCO2e() { co2e }
-    String getCO2eReadable() { Converter.toReadableUnits(co2e,3, 'g') }
+    String getCO2eReadable() { Converter.toReadableUnits(co2e,'m', 'g') }
 
     Double getTime() { time }
     String getTimeReadable() { Converter.toReadableTimeUnits(time, 'ms', 'ms', 'days', 0.0d) }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
@@ -1,6 +1,6 @@
 package nextflow.co2footprint
 
-import nextflow.co2footprint.utils.HelperFunctions
+import nextflow.co2footprint.utils.Converter
 
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
@@ -62,13 +62,13 @@ class CO2Record extends TraceRecord {
     ]
 
     Double getEnergyConsumption() { energy }
-    String getEnergyConsumptionReadable() { HelperFunctions.convertToReadableUnits(energy,3, 'Wh') }
+    String getEnergyConsumptionReadable() { Converter.toReadableUnits(energy,3, 'Wh') }
 
     Double getCO2e() { co2e }
-    String getCO2eReadable() { HelperFunctions.convertToReadableUnits(co2e,3, 'g') }
+    String getCO2eReadable() { Converter.toReadableUnits(co2e,3, 'g') }
 
     Double getTime() { time }
-    String getTimeReadable() { HelperFunctions.convertTimeToReadableUnits(time, 'ms', 'ms', 'days', 0.0d) }
+    String getTimeReadable() { Converter.toReadableTimeUnits(time, 'ms', 'ms', 'days', 0.0d) }
 
     Integer getCPUs() { cpus }
     String getCPUsReadable() { cpus as String }
@@ -80,7 +80,7 @@ class CO2Record extends TraceRecord {
     String getCPUUsageReadable() { cpuUsage as String  }
 
     Long getMemory() { memory }
-    String getMemoryReadable() { HelperFunctions.convertBytesToReadableUnits(memory) }
+    String getMemoryReadable() { Converter.toReadableByteUnits(memory) }
 
     String getName() { name }
     String getNameReadable() { name }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/Converter.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/Converter.groovy
@@ -2,7 +2,10 @@ package nextflow.co2footprint.utils
 
 import java.text.DecimalFormat
 
-class HelperFunctions {
+/**
+ * Functions to convert values
+ */
+class Converter {
 
     /**
      * Changes a number into scientific notation ($x.x \times 10^y$)
@@ -10,7 +13,7 @@ class HelperFunctions {
      * @param value
      * @return
      */
-    static String convertToScientificNotation(Double value) {
+    static String toScientificNotation(Double value) {
         if (value == 0) {
             return value.toString()
         } else if (value <= 999 && value >= 0.001) {
@@ -25,12 +28,13 @@ class HelperFunctions {
 
     /**
      * Convert any unit to readable by taking $10^3$ steps
+     *
      * @param value Value that should be converted
      * @param unitIndex Current position in the unit scales
      * @param unit Name / symbol for the unit
      * @return Converted String with appropriate scale
      */
-    static String convertToReadableUnits(double value, int unitIndex=4, String unit='') {
+    static String toReadableUnits(double value, int unitIndex=4, String unit='') {
         def units = ['p', 'n', 'u', 'm', ' ', 'K', 'M', 'G', 'T', 'P', 'E']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
         
         while (value >= 1000 && unitIndex < units.size() - 1) {
@@ -51,7 +55,7 @@ class HelperFunctions {
      * @param value Amount of bytes
      * @return String of the value together with the appropriate unit
      */
-    static String convertBytesToReadableUnits(double value) {
+    static String toReadableByteUnits(double value) {
         def units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']  // Units: Byte, Kilobyte, Megabyte, Gigabyte, Terabyte, Petabyte, Exabyte
         int unitIndex=0
 
@@ -102,7 +106,7 @@ class HelperFunctions {
      * @param maximumSteps Maximum number of valid time steps to be reported
      * @return String of the readable time
      */
-    static String convertTimeToReadableUnits(
+    static String toReadableTimeUnits(
             def value, String unit='ms',
             String smallestUnit='s', String largestUnit='years',
             Double threshold=null, Integer numSteps=null,
@@ -139,7 +143,7 @@ class HelperFunctions {
             return readableString.trim()
         }
         else {
-            return convertTimeToReadableUnits(
+            return toReadableTimeUnits(
                     value, unit,
                     smallestUnit, units[units.indexOf(largestUnit) - 1],
                     threshold, numSteps, readableString

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/Converter.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/Converter.groovy
@@ -30,23 +30,24 @@ class Converter {
      * Convert any unit to readable by taking $10^3$ steps
      *
      * @param value Value that should be converted
-     * @param unitIndex Current position in the unit scales
+     * @param scope Symbol for scope of the unit (e.g. kilo = k)
      * @param unit Name / symbol for the unit
      * @return Converted String with appropriate scale
      */
-    static String toReadableUnits(double value, int unitIndex=4, String unit='') {
-        def units = ['p', 'n', 'u', 'm', ' ', 'K', 'M', 'G', 'T', 'P', 'E']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
-        
-        while (value >= 1000 && unitIndex < units.size() - 1) {
+    static String toReadableUnits(double value, String scope=' ', String unit='') {
+        def scopes = ['p', 'n', 'u', 'm', ' ', 'K', 'M', 'G', 'T', 'P', 'E']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
+        int scopeIndex = scopes.indexOf(scope)
+
+        while (value >= 1000 && scopeIndex < scopes.size() - 1) {
             value /= 1000
-            unitIndex++
+            scopeIndex++
         }
-        while (value <= 1 && unitIndex > 0) {
+        while (value <= 1 && scopeIndex > 0) {
             value *= 1000
-            unitIndex--
+            scopeIndex--
         }
         value = Math.round( value * 100 ) / 100
-        return "${value} ${units[unitIndex]}${unit}"
+        return "${value} ${scopes[scopeIndex]}${unit}"
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
@@ -4,6 +4,12 @@ import java.text.DecimalFormat
 
 class HelperFunctions {
 
+    /**
+     * Changes a number into scientific notation ($x.x \times 10^y$)
+     *
+     * @param value
+     * @return
+     */
     static String convertToScientificNotation(Double value) {
         if (value == 0) {
             return value.toString()
@@ -17,6 +23,13 @@ class HelperFunctions {
         }
     }
 
+    /**
+     * Convert any unit to readable by taking $10^3$ steps
+     * @param value Value that should be converted
+     * @param unitIndex Current position in the unit scales
+     * @param unit Name / symbol for the unit
+     * @return Converted String with appropriate scale
+     */
     static String convertToReadableUnits(double value, int unitIndex=4, String unit='') {
         def units = ['p', 'n', 'u', 'm', ' ', 'K', 'M', 'G', 'T', 'P', 'E']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
         
@@ -32,6 +45,12 @@ class HelperFunctions {
         return "${value} ${units[unitIndex]}${unit}"
     }
 
+    /**
+     * Adds prefixes such as Mega (MB) to Bytes and calculates correct number.
+     *
+     * @param value Amount of bytes
+     * @return String of the value together with the appropriate unit
+     */
     static String convertBytesToReadableUnits(double value) {
         def units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']  // Units: Byte, Kilobyte, Megabyte, Gigabyte, Terabyte, Petabyte, Exabyte
         int unitIndex=0

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/utils/ConverterTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/utils/ConverterTest.groovy
@@ -2,10 +2,10 @@ package nextflow.co2footprint.utils
 
 import spock.lang.Specification
 
-class HelperFunctionsTest extends Specification  {
+class ConverterTest extends Specification  {
     def 'Should convert correct between times'() {
         when:
-        BigDecimal out = HelperFunctions.convertTime(value, unit, targetUnit)
+        BigDecimal out = Converter.convertTime(value, unit, targetUnit)
 
         then:
         out == expected
@@ -21,7 +21,7 @@ class HelperFunctionsTest extends Specification  {
 
     def 'Should convert time to readable Strings'() {
         when:
-        String out = HelperFunctions.convertTimeToReadableUnits(
+        String out = Converter.convertTimeToReadableUnits(
                 value, unit,
                 smallestUnit, largestUnit,
                 smallestValue, maximumSteps

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/utils/ConverterTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/utils/ConverterTest.groovy
@@ -21,7 +21,7 @@ class ConverterTest extends Specification  {
 
     def 'Should convert time to readable Strings'() {
         when:
-        String out = Converter.convertTimeToReadableUnits(
+        String out = Converter.toReadableTimeUnits(
                 value, unit,
                 smallestUnit, largestUnit,
                 smallestValue, maximumSteps


### PR DESCRIPTION
The motivation behind this PR was to experiment with `git rebase` on the forked repository and switch into the fork for contribution (while introducing small, but useful changes).

## Summary
- Refactor: Renamed `HelperFunctions` to `Converter`, because all functions convert values to a certain format
- Documentation: Improved docstrings in `Converter`
- Refactor: Renamed methods to align naming pattern and avoid redundancy after renaming the class

## Details
- Fix: Had to change the read in of the CI table because it only read the first line. The origin of the error is unknown but I could find no connection the changes. The method `retrieveCi` will be replaced in #181 anyway, so I just made the small fix