### PR TITLE
CI: Request warning reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing_chip.yaml
+++ b/.github/ISSUE_TEMPLATE/missing_chip.yaml
@@ -1,0 +1,49 @@
+name: 'Missing chip'
+description: Report your missing chips.
+title: "Missing chip: <YOUR CHIP>"
+labels: ["💎 enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting :)
+
+  - type: textarea
+    id: warning
+    attributes:
+      label: 'Warning message'
+      description:
+        '>YOUR_WARNING'
+      placeholder: |
+        '>YOUR_WARNING'
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: "Logs:"
+      description:
+        .nextflow.log
+      placeholder: |
+        ```log
+        YOUR_NEXTFLOW_LOG
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    id: other
+    attributes:
+      label: "Other:"
+      description:
+        Other information.
+      placeholder: |
+        -
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Parent issue: #190

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 - Removal of inherited methods in `CO2Record`
 - Adjusted folder structure of tests to main
 - Added a method to extend DataMatrix by rows
+- Added requests to report warnings as Github issues
+- Added template to report missing chips
 
 # Version 1.0.0-beta1
 ## Features:

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
@@ -19,7 +19,7 @@ class CO2FootprintComputer {
 
     /**
      * Constructor for CO2FootprintComputer.
-     * 
+     *
      * @param tdpDataMatrix  Data matrix with CPU TDP (Thermal Design Power) values.
      * @param config         Configuration object with plugin and calculation settings.
      */
@@ -78,7 +78,7 @@ class CO2FootprintComputer {
         if ( cpuUsage == 0.0 ) {
             log.warn("The reported CPU usage is 0.0 for task ${taskID}.")
         }
-        
+
         final BigDecimal coreUsage = cpuUsage / (100.0 * numberOfCores)
 
         /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/TDPDataMatrix.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/TDPDataMatrix.groovy
@@ -145,7 +145,9 @@ class TDPDataMatrix extends DataMatrix {
             log.warn(
                     Markers.unique,
                     "Could not find CPU model \"${originalModel}\" in given TDP data table. " +
-                    "Using ${this.fallbackModel} CPU power draw value (${getTDP(modelData)} W)."
+                    "Using ${this.fallbackModel} CPU power draw value (${getTDP(modelData)} W). " +
+                    'You can help us by reporting this warning and your `.nextflow.log` file to ' +
+                    'https://github.com/nextflow-io/nf-co2footprint/issues/new?template=missing_chip.yaml. Thanks.'
             )
         }
         else {

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/TDPDataMatrixTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/TDPDataMatrixTest.groovy
@@ -213,7 +213,7 @@ class TDPDataMatrixTest extends Specification {
 
         // match against unaccounted variance of model
         df.matchModel('Indel® i3-Fantasy(TM) 10Trillion GW').getData() == [[100, 4, 8]]
-        listAppender.list[1] as String == '[WARN] Could not find CPU model "Intel® i3-Fantasy(TM) 10Trillion GW" in given TDP data table. ' +
+        listAppender.list[1] as String == '[WARN] Could not find CPU model "Indel® i3-Fantasy(TM) 10Trillion GW" in given TDP data table. ' +
                 'Using default CPU power draw value (100.0 W). You can help us by reporting this warning and your ' +
                 '`.nextflow.log` file to https://github.com/nextflow-io/nf-co2footprint/issues/new?template=missing_chip.yaml. Thanks.'
     }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/TDPDataMatrixTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/TDPDataMatrixTest.groovy
@@ -136,7 +136,8 @@ class TDPDataMatrixTest extends Specification {
         dfTDPPerThread == 12.5
         df2TDPPerThread == 5.0
         listAppender.list[0] as String ==  '[WARN] Could not find CPU model "Non-existent" in given TDP data table. ' +
-                'Using default CPU power draw value (100.0 W).'
+                'Using default CPU power draw value (100.0 W). You can help us by reporting this warning and your ' +
+                '`.nextflow.log` file to https://github.com/nextflow-io/nf-co2footprint/issues/new?template=missing_chip.yaml. Thanks.'
         // Second instance should be filtered
         listAppender.list.size() == 1
 
@@ -207,12 +208,14 @@ class TDPDataMatrixTest extends Specification {
         // match against non existent model
         df.matchModel('Non-existent2').getData() == [[100, 4, 8]]
         listAppender.list[0] as String == '[WARN] Could not find CPU model "Non-existent2" in given TDP data table. ' +
-                'Using default CPU power draw value (100.0 W).'
+                'Using default CPU power draw value (100.0 W). You can help us by reporting this warning and your ' +
+                '`.nextflow.log` file to https://github.com/nextflow-io/nf-co2footprint/issues/new?template=missing_chip.yaml. Thanks.'
 
         // match against unaccounted variance of model
         df.matchModel('Indel® i3-Fantasy(TM) 10Trillion GW').getData() == [[100, 4, 8]]
-        listAppender.list[1] as String == '[WARN] Could not find CPU model "Indel® i3-Fantasy(TM) 10Trillion GW" in given TDP data table. ' +
-                'Using default CPU power draw value (100.0 W).'
+        listAppender.list[1] as String == '[WARN] Could not find CPU model "Intel® i3-Fantasy(TM) 10Trillion GW" in given TDP data table. ' +
+                'Using default CPU power draw value (100.0 W). You can help us by reporting this warning and your ' +
+                '`.nextflow.log` file to https://github.com/nextflow-io/nf-co2footprint/issues/new?template=missing_chip.yaml. Thanks.'
     }
 
     @Unroll


### PR DESCRIPTION
## Related Issues
- Addresses #190 
- Addresses #136

## 🎯 Motivation
- Request users to create issues upon warnings

## 📌 Important details
- Added request to report missing chips in the new template
- Added request to create report, when ´cpuUsage == null`
  - No longer included, because cause is most likely the execution outside of a container (i.e. Docker), leading to Nextflow being unable to report some information

## ✅ Checklist
- [x] New functionality is covered by tests
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)