### PR TITLE
Feature: Break on fallback to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Speedier Report generation through refactoring of Co2 aggregation
 - Merge provided custom TDP matrices into the old `TDPDataMatrix`, instead of fully replacing it
 - Added metric to indicate newly generated / non-cached CO2 emissions into report
+- Added support for breaking the program when falling back to defaults
 
 ## Bug Fixes:
 - Adjusted rendering of flights to deliver percentage < 1.0 flights and number of flights afterwards

--- a/docs/usage/parameters.md
+++ b/docs/usage/parameters.md
@@ -67,3 +67,9 @@ The following parameters are currently available:
     - `'compute cluster'`: sets `pue` to 1.67
     - `'cloud'`: sets `pue` to 1.56  
       <sup>Source: [Uptime Institute 2024 Global Data Center Survey](https://datacenter.uptimeinstitute.com/rs/711-RIA-145/images/2024.GlobalDataCenterSurvey.Report.pdf)</sup>
+- 
+- **`fallbackToDefault`**
+  When a parameter can not be matched, the plugin does normally fallback to a default value. When this option is set to `false`, an error is raised and the program terminated instead.
+  This behaviour affects the chip (CPU/GPU) matching and the carbon intensity (CI) location matching.
+  **Default**: `true`
+  

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
@@ -73,7 +73,7 @@ class CO2FootprintComputer {
          * Factors of core power usage
          */
         final Integer numberOfCores = HelperFunctions.getTraceOrDefault(trace, taskID, 'cpus', 1) as Integer           // [#]
-        final BigDecimal powerdrawPerCore = tdpDataMatrix.matchModel(cpuModel).getCoreTDP()            // [W/core]
+        final BigDecimal powerdrawPerCore = tdpDataMatrix.matchModel(cpuModel, config.getFallbackToDefault()).getCoreTDP()            // [W/core]
 
         // uc: core usage factor (between 0 and 1)
         BigDecimal cpuUsage = HelperFunctions.getTraceOrDefault(trace, taskID, '%cpu', numberOfCores * 100) as BigDecimal

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -44,6 +44,7 @@ class CO2FootprintConfig {
     private Double  powerdrawCpuDefault = null
     private String  customCpuTdpFile = null
     private String  machineType = null      // Type of computer on which the workflow is run ['local', 'compute cluster', '']
+    private Boolean fallbackToDefault = true
 
     // Supported machine types
     private final List<String> supportedMachineTypes = ['local', 'compute cluster', 'cloud']
@@ -68,6 +69,7 @@ class CO2FootprintConfig {
     Double getPowerdrawMem() { powerdrawMem }
     String getCustomCpuTdpFile() { customCpuTdpFile }
     String getMachineType()  { machineType }
+    Boolean getFallbackToDefault() { fallbackToDefault }
 
     /**
      * Loads configuration from a map and sets up defaults and fallbacks.

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/DataContainers/TDPDataMatrix.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/DataContainers/TDPDataMatrix.groovy
@@ -6,6 +6,7 @@ import nextflow.co2footprint.utils.Markers
 import groovy.util.logging.Slf4j
 
 import java.nio.file.Path
+import java.security.InvalidKeyException
 import java.util.regex.Matcher
 
 /**
@@ -152,7 +153,9 @@ class TDPDataMatrix extends DataMatrix {
         }
         else {
             if (warnOnMismatch) {
-                log.warn("No match found for '${model}'.")
+                String message = "No match found for '${model}'. Fallback to default set to `${fallbackToDefault}`."
+                log.error(message)
+                throw new InvalidKeyException(message)
             }
             return null
         }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/TDPDataMatrix.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/TDPDataMatrix.groovy
@@ -1,0 +1,5 @@
+import java.security.InvalidKeyException
+
+String message = "No match found for '${model}'. Fallback to default set to `${fallbackToDefault}`."
+log.error(message)
+throw new InvalidKeyException(message)

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/TDPDataMatrix.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/TDPDataMatrix.groovy
@@ -1,5 +1,0 @@
-import java.security.InvalidKeyException
-
-String message = "No match found for '${model}'. Fallback to default set to `${fallbackToDefault}`."
-log.error(message)
-throw new InvalidKeyException(message)

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/DataContainers/TDPDataMatrixTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/DataContainers/TDPDataMatrixTest.groovy
@@ -15,6 +15,7 @@ import spock.lang.Unroll
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.security.InvalidKeyException
 
 @Stepwise
 class TDPDataMatrixTest extends Specification {
@@ -274,5 +275,15 @@ class TDPDataMatrixTest extends Specification {
                 ['tdp (W)', 'cores', 'threads'] as LinkedHashSet,
                 ['Indel® i3-Fantasy', 'Ambere ultraEfficient Processor', 'AMT YPS-x42', 'default', 'Indel i5-Fantasy'] as LinkedHashSet,
         )
+    }
+
+    def 'Should not fallback to default' () {
+        when:
+        // match against non existent model without fallback
+        df.matchModel('Non-existent', false)
+
+        then:
+        Exception e = thrown(InvalidKeyException)
+        e.message == "No match found for 'Non-existent'. Fallback to default set to `false`."
     }
 }


### PR DESCRIPTION
## Related Issues
- Closes #188 

## 🎯 Motivation
- Give the user the chance to avoid unnecessary computations, when they don't want to accept a default value.

## 📋 Summary of changes
- Added the `fallbackToDefault` config parameter to define whether the default value should be used as a fallback when no match is found.

## ✅ Checklist
- [x] New functionalities are covered by tests
- [x] Class structure in `test` reflects class structure in `main`
- [x] Documentation reflects changed behaviour
- [x] `README.md` contains information on or reference to new features
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)
- [ ] Added `falllbackToDefault` to `CI`