### PR TITLE
Refactor: Deescalate access rights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 # Version 1.0.0
 
+
+# Version 1.0.0
+
 ## Bug Fixes:
 - Adjusted rendering of flights to deliver percentage < 1.0 flights and number of flights afterwards
 
 ## Misc
 - Moved call to OS when memory is exceeded into this case to avoid unnecessary calls
 - Testing with MD5 sums for file creation
+- Deescalated access rights of variables for tighter scope
 
 # Version 1.0.0-beta1
 ## Features:

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
@@ -51,18 +51,18 @@ class CO2FootprintComputer {
         /**
          * CPU model information
          */
-        String cpuModel = config.getIgnoreCpuModel() ? 'default' : trace.get('cpu_model') as String
+        final String cpuModel = config.getIgnoreCpuModel() ? 'default' : trace.get('cpu_model') as String
 
         /**
          * Realtime of computation
          */
-        BigDecimal runtime_h = trace.get('realtime') as BigDecimal / (1000*60*60)                  // [h]
+        final BigDecimal runtime_h = trace.get('realtime') as BigDecimal / (1000*60*60)                  // [h]
 
         /**
          * Factors of core power usage
          */
-        Integer numberOfCores = trace.get('cpus') as Integer      // [#]
-        BigDecimal powerdrawPerCore = tdpDataMatrix.matchModel(cpuModel).getCoreTDP()      // [W/core]
+        final Integer numberOfCores = trace.get('cpus') as Integer      // [#]
+        final BigDecimal powerdrawPerCore = tdpDataMatrix.matchModel(cpuModel).getCoreTDP()      // [W/core]
 
         // uc: core usage factor (between 0 and 1)
         BigDecimal cpuUsage = trace.get('%cpu') as BigDecimal
@@ -77,20 +77,20 @@ class CO2FootprintComputer {
         if ( cpuUsage == 0.0 ) {
             log.warn("The reported CPU usage is 0.0 for task ${taskID}.")
         }
-        BigDecimal coreUsage = cpuUsage / (100.0 * numberOfCores)
+        final BigDecimal coreUsage = cpuUsage / (100.0 * numberOfCores)
 
         /**
          * Factors of memory power usage
          */
         Long requestedMemory = trace.get('memory') as Long        // [bytes]
-        Long requiredMemory = trace.get('peak_rss') as Long       // [bytes]
+        final Long requiredMemory = trace.get('peak_rss') as Long       // [bytes]
         if ( requestedMemory == null || requiredMemory > requestedMemory) {
             /**
              * Detect operating system
              */
-            OperatingSystemMXBean OS = { (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean() }()
+            final OperatingSystemMXBean OS = { (OperatingSystemMXBean) ManagementFactory.getOperatingSystemMXBean() }()
 
-            Long availableMemory = OS.getTotalMemorySize() as Long    // [bytes]
+            final Long availableMemory = OS.getTotalMemorySize() as Long    // [bytes]
             log.warn(
                     "The required memory (${requiredMemory/(1024**3)} GB) for the task" +
                     " exceeds the requested memory (${requestedMemory/(1024**3)} GB)." +
@@ -99,17 +99,17 @@ class CO2FootprintComputer {
             requestedMemory = availableMemory
         }
 
-        BigDecimal memory = requestedMemory / 1024**3       // conversion to [GB]
+        final BigDecimal memory = requestedMemory / 1024**3       // conversion to [GB]
 
-        BigDecimal powerdrawMem  = config.getPowerdrawMem() // [W per GB]
+        final BigDecimal powerdrawMem  = config.getPowerdrawMem() // [W per GB]
 
         /**
          * Energy-related factors
          */
-        BigDecimal pue = config.getPue()    // PUE: power usage effectiveness of datacenter [ratio] (>= 1.0)
+        final BigDecimal pue = config.getPue()    // PUE: power usage effectiveness of datacenter [ratio] (>= 1.0)
 
         // CI: carbon intensity [gCO2e kWh−1]
-        BigDecimal ci = config.getCi()
+        final BigDecimal ci = config.getCi()
 
         /**
          * Calculate energy consumption [kWh]
@@ -153,15 +153,15 @@ class CO2FootprintComputer {
      * @return CO2EquivalencesRecord with estimations for sensible comparisons
      */
     CO2EquivalencesRecord computeCO2footprintEquivalences(Double totalCO2) {
-        BigDecimal gCO2 = totalCO2 as BigDecimal / 1000 as BigDecimal       // Conversion to [g] CO2
-        String location = config.getLocation()
+        final BigDecimal gCO2 = totalCO2 as BigDecimal / 1000 as BigDecimal       // Conversion to [g] CO2
+        final String location = config.getLocation()
 
         BigDecimal carKilometers = gCO2 / 175
         if (location && (location != 'US' || !location.startsWith('US-'))) {
             carKilometers = gCO2 / 251
         }
-        BigDecimal treeMonths = gCO2 / 917
-        BigDecimal planePercent = gCO2 * 100 / 50000
+        final BigDecimal treeMonths = gCO2 / 917
+        final BigDecimal planePercent = gCO2 * 100 / 50000
 
         return new CO2EquivalencesRecord(
                 carKilometers,

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -103,9 +103,10 @@ class CO2FootprintConfig {
                 cpuData.fallbackModel = "default $machineType"
             }
             else {
-                String message = "machineType '${machineType}' is not supported." +
+                final String message = "machineType '${machineType}' is not supported." +
                         "Please chose one of ${supportedMachineTypes}."
-                log.error(message, new IllegalArgumentException(message))
+                log.error(message)
+                throw new IllegalArgumentException(message)
             }
         }
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -91,7 +91,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                 session.config.navigate('process') as Map
         )
 
-        ArrayList<TraceObserver> result = new ArrayList(1)
+        final ArrayList<TraceObserver> result = new ArrayList(1)
 
         result.add(
                 new CO2FootprintObserver(

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -59,7 +59,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
     }
 
     protected void getPluginVersion() {
-        def reader = new InputStreamReader(this.class.getResourceAsStream('/META-INF/MANIFEST.MF'))
+        InputStreamReader reader = new InputStreamReader(this.class.getResourceAsStream('/META-INF/MANIFEST.MF'))
         String line
         while ( (line = reader.readLine()) && !version ) {
             def h = line.split(": ")
@@ -91,7 +91,7 @@ class CO2FootprintFactory implements TraceObserverFactory {
                 session.config.navigate('process') as Map
         )
 
-        final result = new ArrayList(1)
+        ArrayList<TraceObserver> result = new ArrayList(1)
 
         result.add(
                 new CO2FootprintObserver(

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -52,14 +52,14 @@ class CO2FootprintFactory implements TraceObserverFactory {
      * Example: If the CPU model is not found it should only be warned once, that a fallback value is used.
      */
     static {
-        LoggerContext lc = LoggerFactory.getILoggerFactory() as LoggerContext   // Get Logging Context
-        TurboFilter dmf = new DeduplicateMarkerFilter([Markers.unique])         // Define DeduplicateMarkerFilter
+        final LoggerContext lc = LoggerFactory.getILoggerFactory() as LoggerContext   // Get Logging Context
+        final TurboFilter dmf = new DeduplicateMarkerFilter([Markers.unique])         // Define DeduplicateMarkerFilter
         dmf.start()
         lc.addTurboFilter(dmf)                                                  // Add filter to context
     }
 
     protected void getPluginVersion() {
-        InputStreamReader reader = new InputStreamReader(this.class.getResourceAsStream('/META-INF/MANIFEST.MF'))
+        final InputStreamReader reader = new InputStreamReader(this.class.getResourceAsStream('/META-INF/MANIFEST.MF'))
         String line
         while ( (line = reader.readLine()) && !version ) {
             def h = line.split(": ")

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
@@ -170,7 +170,7 @@ class CO2FootprintObserver implements TraceObserver {
 
         // make sure parent paths exists
         paths.each {key, path ->
-            Path parent = path.normalize().getParent()
+            final Path parent = path.normalize().getParent()
             if (parent) {
                 Files.createDirectories(parent)
                 return
@@ -199,7 +199,7 @@ class CO2FootprintObserver implements TraceObserver {
             total_co2 += co2Record.getCO2e()
         }
 
-        CO2EquivalencesRecord equivalences = co2FootprintComputer.computeCO2footprintEquivalences(total_co2)
+        final CO2EquivalencesRecord equivalences = co2FootprintComputer.computeCO2footprintEquivalences(total_co2)
 
         // Write report and summary
         co2eSummaryFile.write(total_energy, total_co2, equivalences, config, version)
@@ -281,7 +281,7 @@ class CO2FootprintObserver implements TraceObserver {
         current.remove(taskId)
 
         // Extract CO2e records
-        CO2Record co2Record = co2FootprintComputer.computeTaskCO2footprint(taskId, trace)
+        final CO2Record co2Record = co2FootprintComputer.computeTaskCO2footprint(taskId, trace)
 
         // Collect results
         co2eRecords[taskId] = co2Record
@@ -305,13 +305,13 @@ class CO2FootprintObserver implements TraceObserver {
      */
     void onProcessCached(TaskHandler handler, TraceRecord trace) {
         log.trace("Trace report - cached process > $handler")
-        def taskId = handler.task.id
+        final TaskId taskId = handler.task.id
 
         // event was triggered by a stored task, ignore it
         if (trace == null) { return }
 
         // Extract records
-        CO2Record co2Record = co2FootprintComputer.computeTaskCO2footprint(taskId, trace)
+        final CO2Record co2Record = co2FootprintComputer.computeTaskCO2footprint(taskId, trace)
 
         // Collect results
         co2eRecords[taskId] = co2Record

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintReportSummary.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintReportSummary.groovy
@@ -150,7 +150,7 @@ class CO2FootprintReportSummary {
             }
         }
 
-        private BigDecimal round( double value ) {
+        private static BigDecimal round( double value ) {
             Math.round( value * 100 ) / 100
         }
 
@@ -192,8 +192,8 @@ class CO2FootprintReportSummary {
             if( count==0 )
                 return null
 
-            final result = new LinkedHashMap<String,?>(12)
-            final sorted = tasks.sort( false, { CO2Record co2record -> metric.call(co2record) } )
+            final Map<String, ?> result = new LinkedHashMap<String,?>(12)
+            final List<CO2Record> sorted = tasks.sort( false, { CO2Record co2record -> metric.call(co2record) } )
 
             result.mean = total / count as double
             result.min = quantile(sorted, 0)
@@ -250,14 +250,14 @@ class CO2FootprintReportSummary {
             else {
                 int i = (int)Math.floor(j); int k = (int)Math.ceil(j)
                 label(items[i],q)
-                final Xi = metric.call(items[i])
-                final Xk = metric.call(items[k])
+                final Double Xi = metric.call(items[i])
+                final Double Xk = metric.call(items[k])
                 return Xi + (j-i) * (Xk-Xi)
             }
         }
 
         protected double[] quantiles(List items) {
-            def result = new double[5]
+            double[] result = new double[5]
             result[0] = quantile(items,0)
             result[1] = quantile(items,25)
             result[2] = quantile(items,50)

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintReportSummary.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintReportSummary.groovy
@@ -93,7 +93,7 @@ class CO2FootprintReportSummary {
      *      - q3Label: label fot the task reporting the q3 value
      *      - maxLabel: label fot the task reporting the max value
      */
-    Map<String,?> compute(String name) {
+    Map<String, Object> compute(String name) {
 
         if( !names.contains(name) )
             throw new IllegalArgumentException("Invalid status field name: $name -- it must be one of the following: ${names.join(',')}")
@@ -188,11 +188,11 @@ class CO2FootprintReportSummary {
          *      - q3Label: label fot the task reporting the q3 value
          *      - maxLabel: label fot the task reporting the max value
          */
-        Map<String,?> compute() {
+        Map<String, Object> compute() {
             if( count==0 )
                 return null
 
-            final Map<String, ?> result = new LinkedHashMap<String,?>(12)
+            final Map<String, Object> result = new LinkedHashMap<String, Object>(12)
             final List<CO2Record> sorted = tasks.sort( false, { CO2Record co2record -> metric.call(co2record) } )
 
             result.mean = total / count as double

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2Record.groovy
@@ -16,17 +16,16 @@ import groovy.json.StringEscapeUtils
 @CompileStatic
 class CO2Record extends TraceRecord {
 
-    private Double energy
-    private Double co2e
-    private Double time
-    private Double ci
-    private Integer cpus
-    private Double powerdrawCPU
-    private Double cpuUsage
-    private Long memory
-    private String name
-    private String cpu_model
-    // final? or something? to make sure for key value can be set only once?
+    private final Double energy
+    private final Double co2e
+    private final Double time
+    private final Double ci
+    private final Integer cpus
+    private final Double powerdrawCPU
+    private final Double cpuUsage
+    private final Long memory
+    private final String name
+    private final String cpu_model
 
     CO2Record(Double energy, Double co2e, Double time, Double ci, Integer cpus, Double powerdrawCPU, Double cpuUsage, Long memory, String name, String cpu_model) {
         this.energy = energy
@@ -113,17 +112,17 @@ class CO2Record extends TraceRecord {
 
     @Override
     CharSequence renderJson(StringBuilder result, List<String> fields, List<String> formats) {
-        final QUOTE = '"'
-        final NA = '-'
+        final String QUOTE = '"'
+        final String NA = '-'
         if( result == null ) result = new StringBuilder()
         result.deleteCharAt(result.length() - 1) // remove the last character "}"
         result << ','
         for( int i=0; i<fields.size(); i++ ) {
-            String name = fields[i]
+            final String name = fields[i]
             if ( name == 'name' ) continue // skip the name field (it's already in the key)
             if ( i ) result << ','
-            String format = i<formats?.size() ? formats[i] : null
-            String value = StringEscapeUtils.escapeJavaScript(getFmtStr(name, format) ?: NA)
+            final String format = i<formats?.size() ? formats[i] : null
+            final String value = StringEscapeUtils.escapeJavaScript(getFmtStr(name, format) ?: NA)
             result << QUOTE << name << QUOTE << ":" << QUOTE << value << QUOTE
         }
         result << "}"
@@ -140,7 +139,7 @@ class CO2Record extends TraceRecord {
     @Override
     String getFmtStr( String name, String converter = null ) {
         assert name
-        def val = store.get(name)
+        final val = store.get(name)
 
         String sType=null
         String sFormat=null
@@ -155,20 +154,20 @@ class CO2Record extends TraceRecord {
             }
         }
 
-        String type = sType ?: FIELDS.get(name)
+        final String type = sType ?: FIELDS.get(name)
         if( !type )
             throw new IllegalArgumentException("Not a valid trace field name: '$name'")
 
 
-        Closure<String> formatter = FORMATTER.get(type)
+        final Closure<String> formatter = FORMATTER.get(type)
         if( !formatter )
             throw new IllegalArgumentException("Not a valid trace formatter for field: '$name' with type: '$type'")
 
         try {
-            return formatter.call(val,sFormat)
+            return formatter.call(val, sFormat)
         }
         catch( Throwable ignore ) {
-            log.debug "Not a valid trace value -- field: '$name'; value: '$val'; format: '$sFormat'"
+            log.debug("Not a valid trace value -- field: '$name'; value: '$val'; format: '$sFormat'")
             return null
         }
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/TDPDataMatrix.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/TDPDataMatrix.groovy
@@ -92,7 +92,7 @@ class TDPDataMatrix extends DataMatrix {
                 .replaceAll('\\s(?!\\?)', Matcher.quoteReplacement('\\s*'))                     // make whitespaces optional
 
         // Find matches against index
-        List matches = this.rowIndex.filterKeys { String str ->
+        final List matches = this.rowIndex.filterKeys { String str ->
                 str = str.toLowerCase()                                               // Convert to lower case
                     .replaceAll(' ?(processor|cpu)s? ?', '')        // make 'processor(s)/cpu' optional
                 str.matches(modelRegex)
@@ -200,7 +200,7 @@ class TDPDataMatrix extends DataMatrix {
      */
     Double getCoreTDP(DataMatrix dm=null, Integer rowIdx=0, Object rowID=null) {
         dm = dm ?: this
-        return  getTDP(dm, rowID, rowIdx) / getCores(dm, rowID, rowIdx)
+        return getTDP(dm, rowID, rowIdx) / getCores(dm, rowID, rowIdx)
     }
 
     /**
@@ -213,7 +213,7 @@ class TDPDataMatrix extends DataMatrix {
      */
     Double getThreadTDP(DataMatrix dm=null, Integer rowIdx=0, Object rowID=null) {
         dm = dm ?: this
-        return  getTDP(dm, rowID, rowIdx) / getThreads(dm, rowID, rowIdx)
+        return getTDP(dm, rowID, rowIdx) / getThreads(dm, rowID, rowIdx)
     }
 
     /**
@@ -247,9 +247,11 @@ class TDPDataMatrix extends DataMatrix {
     static compareToOldData(TDPDataMatrix oldData, TDPDataMatrix newData) {
         // Compare entries to warn about changing
         if (oldData) {
+            TDPDataMatrix oldEntry
+            TDPDataMatrix newEntry
             for (String model : oldData.getRowIndex().keySet()) {
-                TDPDataMatrix oldEntry = oldData.matchModel(model, false)
-                TDPDataMatrix newEntry = newData.matchModel(model, false)
+                oldEntry = oldData.matchModel(model, false)
+                newEntry = newData.matchModel(model, false)
                 if (oldEntry && oldEntry.getData() != newEntry.getData()) {
                     log.info(
                             "Already existing TDP value (${oldEntry.getTDP()} W) of '${model}' " +

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/Converter.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/Converter.groovy
@@ -1,9 +1,6 @@
 package nextflow.co2footprint.utils
 
 import java.text.DecimalFormat
-import java.time.ZonedDateTime
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
 
 /**
  * Functions to convert values
@@ -38,7 +35,7 @@ class Converter {
      * @return Converted String with appropriate scale
      */
     static String toReadableUnits(double value, String scope='', String unit='') {
-        def scopes = ['p', 'n', 'u', 'm', '', 'K', 'M', 'G', 'T', 'P', 'E']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
+        final List<String> scopes = ['p', 'n', 'u', 'm', '', 'K', 'M', 'G', 'T', 'P', 'E']  // Units: pico, nano, micro, milli, 0, Kilo, Mega, Giga, Tera, Peta, Exa
         int scopeIndex = scopes.indexOf(scope)
 
         while (value >= 1000 && scopeIndex < scopes.size() - 1) {
@@ -60,7 +57,7 @@ class Converter {
      * @return String of the value together with the appropriate unit
      */
     static String toReadableByteUnits(double value) {
-        def units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']  // Units: Byte, Kilobyte, Megabyte, Gigabyte, Terabyte, Petabyte, Exabyte
+        final List<String> units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB']  // Units: Byte, Kilobyte, Megabyte, Gigabyte, Terabyte, Petabyte, Exabyte
         int unitIndex=0
 
         while (value >= 1024 && unitIndex < units.size() - 1) {
@@ -82,8 +79,8 @@ class Converter {
      */
     static BigDecimal convertTime(def value, String unit='ms', String targetUnit='s') {
         value = value as BigDecimal
-        List<String> units = ['ns', 'mus', 'ms', 's', 'min', 'h', 'days', 'weeks', 'months', 'years']   // Units of time
-        List<Double> steps = [1000.0, 1000.0, 1000.0, 60.0, 60.0, 24.0, 7.0, 4.35, 12.0]                // (Average) magnitude change between units
+        final List<String> units = ['ns', 'mus', 'ms', 's', 'min', 'h', 'days', 'weeks', 'months', 'years']   // Units of time
+        final List<Double> steps = [1000.0, 1000.0, 1000.0, 60.0, 60.0, 24.0, 7.0, 4.35, 12.0]                // (Average) magnitude change between units
 
         int givenUnitPos = units.indexOf(unit)
         int targetUnitPos = units.indexOf(targetUnit)
@@ -121,16 +118,16 @@ class Converter {
         String readableString = ''
     ) {
         // Ordered list of supported time units
-        List<String> units = ['ns', 'mus', 'ms', 's', 'min', 'h', 'days', 'weeks', 'months', 'years']
+        final List<String> units = ['ns', 'mus', 'ms', 's', 'min', 'h', 'days', 'weeks', 'months', 'years']
 
         // Calculate the number of conversion steps left
-        int smallestIdx = units.indexOf(smallestUnit)
-        int largestIdx = units.indexOf(largestUnit)
+        final int smallestIdx = units.indexOf(smallestUnit)
+        final int largestIdx = units.indexOf(largestUnit)
         numSteps = (numSteps == null) ? (largestIdx - smallestIdx) : (numSteps - 1)
 
         // Convert value to the current target unit
         String targetUnit = largestUnit
-        BigDecimal targetValue = convertTime(value as BigDecimal, unit, targetUnit)
+        final BigDecimal targetValue = convertTime(value as BigDecimal, unit, targetUnit)
         def targetValueFormatted = Math.floor(targetValue)
 
         // Singularize unit if value is exactly 1 and unit is plural
@@ -148,18 +145,18 @@ class Converter {
             value = targetValue - targetValueFormatted
             unit = largestUnit
             // Format to 2 decimals, remove trailing zeros
-            String formattedValue = (targetValueFormatted as BigDecimal).setScale(2, BigDecimal.ROUND_HALF_UP).stripTrailingZeros().toPlainString()
+            final String formattedValue = (targetValueFormatted as BigDecimal).setScale(2, BigDecimal.ROUND_HALF_UP).stripTrailingZeros().toPlainString()
             readableString += readableString ? " ${formattedValue}${targetUnit}" : "${formattedValue}${targetUnit}"
         }
 
         // If we've reached the smallest unit or max steps, return the result
         if (numSteps == 0) {
-            String result = readableString.trim()
+            final String result = readableString.trim()
             return result ? result : "0${smallestUnit}"
         }
 
         // Otherwise, continue with the next smaller unit
-        String nextLargestUnit = units[largestIdx - 1]
+        final String nextLargestUnit = units[largestIdx - 1]
         return toReadableTimeUnits(
                 value, unit,
                 smallestUnit, nextLargestUnit,

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/Converter.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/Converter.groovy
@@ -1,5 +1,6 @@
 package nextflow.co2footprint.utils
 
+import java.math.RoundingMode
 import java.text.DecimalFormat
 
 /**
@@ -145,7 +146,7 @@ class Converter {
             value = targetValue - targetValueFormatted
             unit = largestUnit
             // Format to 2 decimals, remove trailing zeros
-            final String formattedValue = (targetValueFormatted as BigDecimal).setScale(2, BigDecimal.ROUND_HALF_UP).stripTrailingZeros().toPlainString()
+            final String formattedValue = (targetValueFormatted as BigDecimal).setScale(2, RoundingMode.HALF_UP).stripTrailingZeros().toPlainString()
             readableString += readableString ? " ${formattedValue}${targetUnit}" : "${formattedValue}${targetUnit}"
         }
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/DataContainers.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/DataContainers.groovy
@@ -1,9 +1,9 @@
 package nextflow.co2footprint.utils
 
-import java.nio.file.Path
-import java.nio.file.Files
 import groovy.util.logging.Slf4j
 
+import java.nio.file.Path
+import java.nio.file.Files
 
 /**
  * Bidirectional Map with maintained K-V pairs in both directions
@@ -80,14 +80,14 @@ class BiMap<K, V> {
 
     // method to remove a key-value pair based on the key
     V removeByKey(K key) {
-        V value = keyToValueMap.remove(key)
+        final V value = keyToValueMap.remove(key)
         valueToKeyMap.remove(value)
         return value
     }
 
     // method to remove a key-value pair based on the key
     K removeByValue(V value) {
-        K key = valueToKeyMap.remove(value)
+        final K key = valueToKeyMap.remove(value)
         keyToValueMap.remove(key)
         return key
     }
@@ -114,15 +114,15 @@ class BiMap<K, V> {
     }
 
     BiMap<K,V> sortByValues() {
-        List<V> values = valueToKeyMap.keySet().sort()
-        List<K> keys = values.collect { value -> valueToKeyMap[value]}
+        final List<V> values = valueToKeyMap.keySet().sort()
+        final List<K> keys = values.collect { value -> valueToKeyMap[value]}
 
         return new BiMap(null, keys, values)
     }
 
     BiMap<K,V> sortByKeys() {
-        List<K> keys = keyToValueMap.keySet().sort()
-        List<V> values = keys.collect { key -> keyToValueMap[key]}
+        final List<K> keys = keyToValueMap.keySet().sort()
+        final List<V> values = keys.collect { key -> keyToValueMap[key]}
 
         return new BiMap(null, keys, values)
     }
@@ -161,7 +161,7 @@ interface Matrix {
  */
 @Slf4j
 class DataMatrix implements Matrix {
-    List<List<Object>> data = []
+    protected List<List<Object>> data = []
     protected BiMap<Object, Integer> columnIndex = [:] as BiMap
     protected BiMap<Object, Integer> rowIndex = [:] as BiMap
 
@@ -264,30 +264,30 @@ class DataMatrix implements Matrix {
     void assertRowLengthEqual() throws IllegalStateException  {
        data.eachWithIndex { row, i ->
            if (row.size() != this.data[0].size()) {
-               throw new IllegalStateException(
-                       "Length of row ${i} (${row.size()}) does not match size preceding rows (${this.data[0].size()})."
-               )
+               final String message = "Length of row ${i} (${row.size()}) does not match size preceding rows (${this.data[0].size()})."
+               log.error(message)
+               throw new IllegalStateException(message)
            }
        }
     }
 
     private void assertRowIndexLengthMatches() throws IllegalStateException {
         if (this.data.size() != this.rowIndex.size()) {
-            throw new IllegalStateException(
-                    "Data size ${this.data.size()} does not match rowIndex length ${this.rowIndex.size()}"
-            )
+            final String message = "Data size ${this.data.size()} does not match rowIndex length ${this.rowIndex.size()}"
+            log.error(message)
+            throw new IllegalStateException(message)
         }
     }
 
     void assertColumnIndexLengthMatches() throws IllegalStateException  {
         if (this.data.size() == 0 && this.columnIndex.size() != 0) {
-            throw new IllegalStateException(
-                    'Passed column index without data.'
-            )
+            final String message = 'Passed column index without data.'
+            log.error(message)
+            throw new IllegalStateException(message)
         } else if (this.data.size() > 0 && this.data[0].size() != this.columnIndex.size()) {
-            throw new IllegalStateException(
-                    "Data length ${this.data[0].size()} does not match rowIndex length ${this.columnIndex.size()}"
-            )
+            final String message = "Data length ${this.data[0].size()} does not match rowIndex length ${this.columnIndex.size()}"
+            log.error(message)
+            throw new IllegalStateException(message)
         }
     }
 
@@ -324,7 +324,7 @@ class DataMatrix implements Matrix {
      * Select rows of the DataMatrix
      */
     private DataMatrix selectRows(LinkedHashSet<Object> rows){
-        List<Integer> iList = collectIndices(rows, this.rowIndex)
+        final List<Integer> iList = collectIndices(rows, this.rowIndex)
         List<List<Object>> data = this.data[iList]
 
         return new DataMatrix(data, this.columnIndex.keySet() as LinkedHashSet, rows)
@@ -335,7 +335,7 @@ class DataMatrix implements Matrix {
      */
     private DataMatrix selectColumns(LinkedHashSet<Object> columns){
         // Collect indices
-        List<Integer> iList = collectIndices(columns, this.columnIndex)
+        final List<Integer> iList = collectIndices(columns, this.columnIndex)
         List<List<Object>> data = this.data.collect { row -> row[iList] }
 
         return new DataMatrix(data, columns, this.rowIndex.keySet() as LinkedHashSet)
@@ -398,13 +398,17 @@ class DataMatrix implements Matrix {
         // Resolve row index
         row = rowRawIndex ? row as Integer : this.rowIndex.getValue(row)
         if (row == null) {
-            throw new IllegalArgumentException("Row '${rowRawIndex ? row : row as String}' not found in the row index.")
+            final String message = "Row '${rowRawIndex ? row : row as String}' not found in the row index."
+            log.error(message)
+            throw new IllegalArgumentException(message)
         }
 
         // Resolve column index
         column = columnRawIndex ? column as Integer : this.columnIndex.getValue(column)
         if (column == null) {
-            throw new IllegalArgumentException("Column '${columnRawIndex ? column : column as String}' not found in the column index.")
+            final String message = "Column '${columnRawIndex ? column : column as String}' not found in the column index."
+            log.error(message)
+            throw new IllegalArgumentException(message)
         }
 
         // Return the data at the resolved row and column
@@ -440,7 +444,7 @@ class DataMatrix implements Matrix {
             }
             csvString = csvString + '\n'
         }
-        byte[] byteString = csvString.getBytes()
+        final byte[] byteString = csvString.getBytes()
 
         Files.write(path, byteString)
     }
@@ -458,7 +462,7 @@ class DataMatrix implements Matrix {
      * Convert the class into a readable / printable String.
      */
     String toString() {
-        LinkedHashSet<Object> sortedColumnsIndex = getOrderedColumnKeys()
+        final LinkedHashSet<Object> sortedColumnsIndex = getOrderedColumnKeys()
         String stringRepresentation = "\t\t${sortedColumnsIndex.toString()}"
         data.eachWithIndex {row, i  ->
             stringRepresentation += "\n${this.rowIndex.getKey(i)}\t${row.toString()}"

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/LoggingAdapters.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/LoggingAdapters.groovy
@@ -69,7 +69,7 @@ class DeduplicateMarkerFilter extends TurboFilter {
             if (filteredMarkers.contains(marker)) {
 
                 // Counts the occurrences for the markers
-                Integer count = msgCache.putIfAbsent(format, 0) ?: 0
+                final Integer count = msgCache.putIfAbsent(format, 0) ?: 0
 
                 // Increments the occurrences by 1
                 msgCache[format] = count + 1


### PR DESCRIPTION
## Related Issues
- Closes #151

## 🎯 Motivation
- Ensure a tight and controlled environment for programming
- Make execution quicker by minimizing new variable assignments

## 📋 Summary of changes
- Deescalated access rights of variables by using `private` and `final`
- Used `<Type>` instead of `def` to minimize inference at runtime

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)