### PR TITLE
Logging to trace deescalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 
 # Version 1.0.0
+## Features:
+- When a message is excluded from the log it is still sent to the `trace` level log
 
 ## Bug Fixes:
 - Adjusted rendering of flights to deliver percentage < 1.0 flights and number of flights afterwards

--- a/docs/usage/output.md
+++ b/docs/usage/output.md
@@ -3,6 +3,8 @@ title: Output
 description: Output of the nf-co2footprint plugin.
 ---
 
+### Files:
+
 The nf-co2footprint plugin creates three output files:
 
 - **`traceFile`**  
@@ -14,5 +16,5 @@ The nf-co2footprint plugin creates three output files:
 - **`reportFile`**  
   The HTML report contains information about the carbon footprint of the whole pipeline run as well as plots showing the distributions of the CO₂ emissions for the different processes. Additionally, it contains a table with the metrics for all individual tasks.
 
-
-
+### Logging:
+Log messages might be shown to indicate problems, the success of steps, or issue warnings about potentially unwanted behaviour. By default some of them are deduplicated, meaning that the exact same message is only displayed once, despite possibly being reissued for another task. To see the messages that are discarded this way use `nextflow -trace ...` to start your run. The messages are then sent to the `.nextflow.log` file with the `[DUPLICATE]` tag.

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/LoggingAdapters.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/LoggingAdapters.groovy
@@ -23,26 +23,30 @@ class Markers {
  */
 class DeduplicateMarkerFilter extends TurboFilter {
 
-    /**
-     * Markers to be Filtered
-     */
+    // Markers to be Filtered
     private List<Marker> filteredMarkers
 
-    /**
-     * Number of allowed Repetitions of a message
-     */
+    // Number of allowed Repetitions of a message
     public int allowedOccurrences
 
-    /**
-     * Cached messages with count
-     */
+    //Cached messages with count
     private ConcurrentHashMap<String, Integer> msgCache
 
+    /**
+     * Generate Filter which sends all duplicates to TRACE as [DUPLICATE]
+     * after the maximum number of repetitions is exceeded
+     *
+     * @param filteredMarkers Markers to be filtered for (all other markers are ignored)
+     * @param allowedOccurrences Number of allowed occurrences of a message
+     */
     DeduplicateMarkerFilter(List<Marker> filteredMarkers, int allowedOccurrences=1) {
         this.filteredMarkers = filteredMarkers
         this.allowedOccurrences = allowedOccurrences
     }
 
+    /**
+     * Start the filter
+     */
     @Override
     void start() {
         if (filteredMarkers) {
@@ -51,6 +55,9 @@ class DeduplicateMarkerFilter extends TurboFilter {
         }
     }
 
+    /**
+     * Stop the filter
+     */
     @Override
     void stop() {
         msgCache.clear()
@@ -58,6 +65,17 @@ class DeduplicateMarkerFilter extends TurboFilter {
         super.stop()
     }
 
+    /**
+     * Check whether the message is duplicated and log it to TRACE if the maximum number of occurrences is exceeded.
+     *
+     * @param marker Marker of the log message
+     * @param logger The logger the received the message
+     * @param level Level of the log
+     * @param format Message as a formatted string
+     * @param params Parameters passed to the log to be filled into the message string
+     * @param t Throwable exception
+     * @return NEUTRAL, DENY, and ACCEPT command for the Logger
+     */
     @Override
     FilterReply decide(Marker marker, Logger logger, Level level, String format, Object[] params, Throwable t) {
             // Check whether the Filter started
@@ -77,6 +95,8 @@ class DeduplicateMarkerFilter extends TurboFilter {
                 if (count < allowedOccurrences) {
                     return FilterReply.ACCEPT
                 } else {
+                    // Send a TRACE message when the message was not accepted
+                    logger.trace('[DUPLICATE] ' + format, params)
                     return FilterReply.DENY
                 }
             } else {
@@ -109,6 +129,10 @@ class DeduplicateMarkerFilter extends TurboFilter {
         filteredMarkers.add(marker)
     }
 
+    /**
+     * Remove a Marker from the list of filtered Markers
+     * @param marker Marker or name of marker to be removed
+     */
     void removeFilteredMarker(def marker) {
         marker = marker instanceof Marker ? marker : MarkerFactory.getMarker(marker as String)
         filteredMarkers.remove(marker)


### PR DESCRIPTION
## Related Issues
- Closes #195

## 🎯 Motivation
- Give the user a possibility to see duplicated messages (and warnings) which are suppressed. This may aid in avoiding confusion when someone looks in the code and thinks that there should be a warning.

## 📋 Summary of changes
- Added Docstrings
- Added sending to trace upon denial of message

## ✅ Checklist
- [x] Class structure in `test` reflects class structure in `main`
- [x] Documentation reflects changed behaviour
- [x] `README.md` contains information on or reference to new features
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)