### PR TITLE
Update `collectIndices` method to address bug 

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/DataContainers.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/DataContainers.groovy
@@ -312,11 +312,26 @@ class DataMatrix implements Matrix {
     }
 
     /**
-     * Collect indices via keys from a BiMap
-     */
+    * Collects the integer indices for a set of keys from a BiMap.
+    *
+    * For each key in the provided set, this method searches the BiMap's key set for a matching key
+    * (using string representation for comparison). If a key is not found, a warning is logged and
+    * the key is skipped. The resulting list contains only the indices for keys that were found.
+    *
+    * @param keys   The set of keys to look up.
+    * @param bimap  The BiMap mapping keys to integer indices.
+    * @return       A list of integer indices corresponding to the found keys, in the order of input keys.
+    */
     private static List<Integer> collectIndices(LinkedHashSet<Object> keys, BiMap<Object, Integer> bimap) {
-        List<Integer> indices = keys.collect( { key -> bimap.getValue(key) } )
-        indices.removeAll( {it == null })
+        List<Integer> indices = keys.collect { key ->
+            def foundKey = bimap.keySet().find {it.toString() == key.toString()}
+            if (foundKey == null) {
+                log.warn("Key '${key}' not found in in the row index!}")
+                return null
+            }
+            return bimap.getValue(foundKey)
+        }
+        indices.removeAll { it == null }
         return indices
     }
 


### PR DESCRIPTION
The updated `collectIndices` method in `DataMatrix` now robustly matches keys by comparing their string representations, ensuring that keys with equivalent string values (even if of different types) are correctly identified in the BiMap. If a key is not found, it logs a clear warning and skips that key, preventing downstream errors caused by missing indices. 

## Related Issues
- Closes #226, as this was the root cause for the bug 

## ✅ Checklist
- [x] New functionalities are covered by tests
- [x] Class structure in `test` reflects class structure in `main`
- [x] Ensure all tests pass (`.\gradlew check`)