### PR TITLE
Feature: Collect carbon intensities during computation

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
@@ -8,6 +8,11 @@ import groovy.util.logging.Slf4j
 import nextflow.processor.TaskId
 import nextflow.trace.TraceRecord
 
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentSkipListSet
+
 
 /**
  * Class for computation of energy usage, CO2 emission, and equivalence metrics.
@@ -30,7 +35,6 @@ class CO2FootprintComputer {
         this.tdpDataMatrix = tdpDataMatrix
         this.config = config
     }
-
 
     /**
     * Computes the CO2 emissions and energy usage for a given Nextflow task.
@@ -122,7 +126,7 @@ class CO2FootprintComputer {
         final BigDecimal pue = config.getPue()    // PUE: power usage effectiveness of datacenter [ratio] (>= 1.0)
 
         // CI: carbon intensity [gCO2e kWh−1]
-        final BigDecimal ci = config.getCi()
+        final BigDecimal ci = timeCi ? getAverageCI(trace) : config.getCi()
 
         /**
          * Calculate energy consumption [kWh]

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -8,6 +8,7 @@ import nextflow.co2footprint.DataContainers.CIValueComputer
 import nextflow.co2footprint.DataContainers.TDPDataMatrix
 import nextflow.trace.TraceHelper
 import java.nio.file.Paths
+import java.time.LocalDateTime
 
 /**
  * Configuration class for CO₂ footprint calculations.
@@ -60,7 +61,18 @@ class CO2FootprintConfig {
      * If set as a closure (for real-time API), invokes it to get the current value.
      */
     Double getCi() {
-        (ci instanceof Closure) ? (ci as Closure<Double>)() : ci
+        (ci instanceof Closure) ?
+                (ci as Closure<Map<LocalDateTime, Double>>)().values()[0] :
+                (ci as Map<LocalDateTime, Double>).values()[0]
+    }
+    /**
+     * Returns the carbon intensity at timestamps
+     * @return
+     */
+    Map<LocalDateTime, Double> getTimeCi(){
+        (ci instanceof Closure) ?
+                (ci as Closure<Map<LocalDateTime, Double>>)() :
+                ci
     }
     Double getPue() { pue }
     Boolean getIgnoreCpuModel() { ignoreCpuModel }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
@@ -10,6 +10,7 @@ import nextflow.co2footprint.Records.CO2RecordAggregator
 import nextflow.co2footprint.FileCreators.CO2FootprintReport
 import nextflow.co2footprint.FileCreators.CO2FootprintSummary
 import nextflow.co2footprint.FileCreators.CO2FootprintTrace
+import nextflow.co2footprint.Records.TimeCiRecords
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskId
 import nextflow.processor.TaskProcessor
@@ -64,6 +65,10 @@ class CO2FootprintObserver implements TraceObserver {
     private CO2FootprintComputer co2FootprintComputer
     CO2FootprintComputer getCO2FootprintComputer() { co2FootprintComputer }
 
+    // Record for CI values during execution
+    TimeCiRecords timeCiRecords
+    TimeCiRecords getTimeCiRecords() { timeCiRecords }
+
     // Holds the the start time for tasks started/submitted but not yet completed
     @PackageScope
     Map<TaskId, TraceRecord> current = new ConcurrentHashMap<>()
@@ -105,6 +110,8 @@ class CO2FootprintObserver implements TraceObserver {
         this.co2FootprintComputer = co2FootprintComputer
         this.overwrite = overwrite
         this.maxTasks = maxTasks
+
+        this.timeCiRecords = new TimeCiRecords(config)
     }
 
     /**
@@ -144,6 +151,9 @@ class CO2FootprintObserver implements TraceObserver {
         this.session = session
         this.aggregator = new CO2RecordAggregator()
 
+        // Start hourly CI updating
+        timeCiRecords.start()
+
         // make sure parent paths exists
         paths.each {key, path ->
             final Path parent = path.normalize().getParent()
@@ -167,6 +177,9 @@ class CO2FootprintObserver implements TraceObserver {
     void onFlowComplete() {
         log.debug("Workflow completed -- rendering & saving files")
 
+        // Stop hourly CI updating
+        timeCiRecords.stop()
+
         // Compute the statistics (total, mean, min, max, quantiles) on process level
         final Map<String, Map<String, Map<String, ?>>> processStats = aggregator.computeProcessStats()
 
@@ -185,7 +198,11 @@ class CO2FootprintObserver implements TraceObserver {
         // Write report and summary
         co2eSummaryFile.write(totalStats, equivalences, config, version)
 
-        co2eReportFile.addEntries(totalStats, processStats, equivalences, config, version, session, traceRecords, co2eRecords)
+        co2eReportFile.addEntries(
+                totalStats, processStats, equivalences,
+                config, version, session,
+                traceRecords, co2eRecords, timeCiRecords.getTimeCi()
+        )
         co2eReportFile.write()
 
         // Close all files (writes remaining tasks in the trace file)

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/DataContainers/CIValueComputer.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/DataContainers/CIValueComputer.groovy
@@ -6,6 +6,9 @@ import groovy.util.logging.Slf4j
 import nextflow.co2footprint.utils.Markers
 import groovy.json.JsonSlurper
 
+import java.text.DateFormat
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 /**
  * Class to compute carbon intensity (CI) values.
@@ -37,7 +40,7 @@ class CIValueComputer {
      * @param processName (Optional) The process name for logging/marker purposes.
      * @return The carbon intensity value as a Double, or null if not found.
      */
-    protected Double getRealtimeCI() {
+    protected Map<LocalDateTime, Double> getRealtimeCI() {
         // Build the API URL
         URL url = new URI("https://api.electricitymap.org/v3/carbon-intensity/latest?zone=${this.location}").toURL()
 
@@ -47,10 +50,13 @@ class CIValueComputer {
 
         Map json
         Double ci
+        LocalDateTime time
 
         if (connection.responseCode == 200) {
             // Parse the successful API response
             json = new JsonSlurper().parse(connection.inputStream) as Map
+
+            time = LocalDateTime.parse(json['datetime'] as String)
             ci = json['carbonIntensity'] as Double
 
             log.info(Markers.unique,"API call successful. Response code: ${connection.responseCode} (${connection.responseMessage})")
@@ -61,6 +67,7 @@ class CIValueComputer {
 
             log.warn(Markers.unique, "API call failed. Response code: ${connection.responseCode} (${errorMessage})")
 
+            time = LocalDateTime.now()
             // Fallback to the location in the CSV
             ci = this.ciData.findCiInMatrix(this.location)
             // Fallback to the global default value if no value is found for the location
@@ -68,7 +75,7 @@ class CIValueComputer {
                 ci = this.ciData.findCiInMatrix('GLOBAL')
             }
         }
-        return ci
+        return [(time): ci]
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/CO2FootprintReport.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/CO2FootprintReport.groovy
@@ -1,6 +1,7 @@
 package nextflow.co2footprint.FileCreators
 
 import groovy.json.JsonOutput
+import nextflow.co2footprint.CO2FootprintComputer
 import nextflow.co2footprint.Records.CO2EquivalencesRecord
 import nextflow.co2footprint.CO2FootprintConfig
 import nextflow.co2footprint.Records.CO2Record
@@ -16,6 +17,7 @@ import nextflow.trace.TraceHelper
 import nextflow.trace.TraceRecord
 
 import java.nio.file.Path
+import java.time.LocalDateTime
 
 
 /**
@@ -39,6 +41,7 @@ class CO2FootprintReport extends CO2FootprintFile{
     private Session session
     private Map<TaskId, TraceRecord> traceRecords
     private Map<TaskId, CO2Record> co2eRecords
+    private Map<LocalDateTime, Double> timeCiRecords
 
     // Writer for the HTML file
     private BufferedWriter writer = TraceHelper.newFileWriter(path, overwrite, 'Report')
@@ -66,6 +69,7 @@ class CO2FootprintReport extends CO2FootprintFile{
      * @param session       Nextflow session
      * @param traceRecords  Map of TaskId to TraceRecord
      * @param co2eRecords   Map of TaskId to CO2Record
+     * @param timeCiRecords   Map of LocalDateTime to carbon intensities
      */
     void addEntries(
             Map<String, Double> totalStats,
@@ -75,7 +79,8 @@ class CO2FootprintReport extends CO2FootprintFile{
             String version,
             Session session,
             Map<TaskId, TraceRecord> traceRecords,
-            Map<TaskId, CO2Record> co2eRecords
+            Map<TaskId, CO2Record> co2eRecords,
+            Map<LocalDateTime, Double> timeCiRecords
     ) {
         this.totalStats = totalStats
         this.processStats = processStats
@@ -85,6 +90,9 @@ class CO2FootprintReport extends CO2FootprintFile{
         this.session = session
         this.traceRecords = traceRecords
         this.co2eRecords = co2eRecords
+        this.timeCiRecords = timeCiRecords
+        // TODO: Add CI Records into Report
+        // TODO: Testing TimeCiRecords
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Records/TimeCiRecords.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Records/TimeCiRecords.groovy
@@ -1,0 +1,88 @@
+package nextflow.co2footprint.Records
+
+import nextflow.co2footprint.CO2FootprintConfig
+import nextflow.trace.TraceRecord
+
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.ConcurrentHashMap
+
+class TimeCiRecords {
+    // Timer for cyclical tasks
+    private Timer timer = new Timer(true) // true = daemon thread
+
+    // CI values
+    private ConcurrentHashMap<LocalDateTime, Double> timeCi
+
+    // Config
+    private CO2FootprintConfig config
+
+    TimeCiRecords(CO2FootprintConfig config, ConcurrentHashMap<LocalDateTime, Double> timeCi=[:] as ConcurrentHashMap) {
+        this.config = config
+        this.timeCi = timeCi as ConcurrentHashMap
+    }
+
+    ConcurrentHashMap<LocalDateTime, Double> getTimeCi() { timeCi }
+
+    /**
+     * Adds time CI pairs to CI record
+     *
+     * @param timeCi Map of LocalDateTime and Double that is added to the CI record
+     */
+    private void add(Map<LocalDateTime, Double> timeCi=this.config.getTimeCi()) {
+        this.timeCi.putAll(timeCi)
+    }
+
+    /**
+     * Start the update process with new CI values if ci is a function
+     *
+     * @param config Configuration instance with ci value / function
+     */
+    void start(CO2FootprintConfig config=this.config) {
+        if (config.ci instanceof Closure) {
+            timer.scheduleAtFixedRate(new TimerTask() {
+                void run() {
+                    add(config.getTimeCi())
+                }
+            }, 0, 1000 * 60 * 60) // Delay = 0ms, repeat every 1 hour
+        }
+    }
+
+    /**
+     * Stops the CI value accumulation
+     */
+    void stop() {
+        timer.cancel()
+        timer.purge()
+    }
+
+    /**
+     * Returns the average carbon intensity
+     * @param trace
+     * @return
+     */
+    Double getAverageCI(TraceRecord trace, Map<LocalDateTime, Double> timeCi=this.timeCi) {
+        LocalDateTime start = LocalDateTime.parse(trace.get('start') as String)
+        LocalDateTime end = LocalDateTime.parse(trace.get('complete') as String)
+        Long duration = start.until(end, ChronoUnit.MILLIS)
+
+        Double averageCi = 0d
+
+        // Construct before, during and after key sets
+        Set<LocalDateTime> during = timeCi.keySet().clone() as Set<LocalDateTime>
+        Set<LocalDateTime> before = during.findAll {LocalDateTime time -> time < start}
+        during.removeAll(before)
+        Set<LocalDateTime> after = during.findAll {LocalDateTime time -> time > end}
+        during.removeAll(after)
+
+        // Add edge cases (start & end) to average ci by weight
+        averageCi += timeCi.get(before.max()) * (start.until(during.min(), ChronoUnit.MILLIS) / duration)
+        averageCi += timeCi.get(after.min()) * (during.max().until(end, ChronoUnit.MILLIS) / duration)
+
+        // Add weighted average of fully covered duration
+        averageCi += timeCi.subMap(during).values().average() * (during.min().until(during.max(), ChronoUnit.MILLIS) / duration)
+
+
+        return averageCi
+    }
+}


### PR DESCRIPTION
## Related Issues
- Closes #194
- Closes #200

## 🎯 Motivation
- Use execution time information to calculate the carbon intensity during execution
- Depict the carbon intensity during the run

## 📋 Summary of changes
- Added `TimeCiRecords` as a collector of CI values during execution

## 📌 Important details
- The CI value computation from the table still happens separately

## ✅ Checklist
- [ ] New functionalities are covered by tests
- [ ] Class structure in `test` reflects class structure in `main`
- [ ] Documentation reflects changed behaviour
- [ ] `README.md` contains information on or reference to new features
- [ ] `CHANGELOG.md` is updated with a note on your changes
- [ ] Ensure all tests pass (`.\gradlew check`)