### PR TITLE
Logging: Rephrase executor not mapped warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Changed Javascript method to use Converter methods
 - Modified Aggregator to include TraceRecords for tracking of CACHED processes
 - Moved non nf-hello template files into categorizing folder structure (except `CO2FootprintComputer`)
+- Changed missing executor logging to indicate a still functioning run
 
 # Version 1.0.0-beta1
 ## Features:

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -148,16 +148,19 @@ class CO2FootprintConfig {
      */
     private void setMachineTypeAndPueFromExecutor(String executor) {
         // Read the CSV file as a DataMatrix - set RowIndex to 'executor'
-        DataMatrix matrix = DataMatrix.fromCsv(Paths.get(this.class.getResource('/executor_machine_pue_mapping.csv').toURI()), ',', 0, null, 'executor')
-        // Check if matrix contains the required columns
-        matrix.checkRequiredColumns(['machineType', 'pue'])
-        try {
-            this.machineType = matrix.get(executor, 'machineType') as String
-            this.pue ?= matrix.get(executor, 'pue') as Double // assign pue only if not already set
-        } catch (IllegalArgumentException ignore) {
-            log.warn("Executor '${executor}' is not supported. MachineType set to null.")
-        }
+    DataMatrix machineTypeMatrix = DataMatrix.fromCsv(Paths.get(this.class.getResource('/executor_machine_pue_mapping.csv').toURI()), ',', 0, null, 'executor')
+    // Check if matrix contains the required columns
+    machineTypeMatrix.checkRequiredColumns(['machineType', 'pue'])
+    if (machineTypeMatrix.rowIndex.containsKey(executor)) {
+        this.machineType = machineTypeMatrix.get(executor, 'machineType') as String
+        this.pue ?= machineTypeMatrix.get(executor, 'pue') as Double // assign pue only if not already set
     }
+    else {
+        log.warn(
+                "Executor '${executor}' is not mapped. MachineType set to null." +
+                "To eliminate this warning you can set `machineType` in the config to one of ${supportedMachineTypes}.")
+    }
+}
 
     /**
      * Collects input file options for reporting.


### PR DESCRIPTION
## Related Issues
- Closes #245 

## 🎯 Motivation
- Indicate that it is not vital that the executor is set and give hints to eliminate the warning

## 📋 Summary of changes
- Changing the warning

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)