### PR TITLE
Make HTML tasks table column names more consistent and concise

### DIFF
--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
@@ -369,11 +369,11 @@ $(function() {
       }
 
       // Column titles
-      var energyConsumptionTitle = 'energy consumption (mWh)'; // Default column title
-      var co2EmissionsTitle = 'CO2e emissions (mg)';
+      var energyConsumptionTitle = 'Energy consumption (mWh)'; // Default column title
+      var co2EmissionsTitle = 'CO₂e emissions (mg)';
       if ($('#nf-table-humanreadable').val() == 'true') {
-        energyConsumptionTitle = 'energy consumption'; // Change the column title if the button is selected
-        co2EmissionsTitle = 'CO2e emissions';
+        energyConsumptionTitle = 'Energy consumption'; // Change the column title if the button is selected
+        co2EmissionsTitle = 'CO₂e emissions';
       }
 
       var table = $('#tasks_table').DataTable({
@@ -412,7 +412,7 @@ $(function() {
           { title: 'Time', data: 'time', type: 'num', render: make_time },
           { title: 'Carbon Intensity', data: 'ci', type: 'num', render: make_carbon_intensity },
           { title: 'Number of cores', data: 'cpus', type: 'num' },
-          { title: 'Power draw of a computing core', data: 'powerdrawCPU', type: 'num'},
+          { title: 'Power draw per core', data: 'powerdrawCPU', type: 'num'},
           { title: 'Core usage factor', data: 'cpuUsage', type: 'num', render: make_core_usage_factor },
           { title: 'Memory', data: 'memory', type: 'num', render: make_memory },
           { title: 'CPU model', data: 'cpu_model' },

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintObserverTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintObserverTest.groovy
@@ -267,7 +267,7 @@ class CO2FootprintObserverTest extends Specification{
         // 246 is the plugin version
         checksumChecker.compareChecksums(
                 reportPath,
-                'e1299389272b334e2891dbb0190d2c16',
+                'c26967cb59fcbb752dc89bac422e9f8d',
                 [233, 246, 1292],
                 this.class.getResource('/report_test.html').getPath() as Path
         )

--- a/plugins/nf-co2footprint/src/testResources/report_test.html
+++ b/plugins/nf-co2footprint/src/testResources/report_test.html
@@ -1155,11 +1155,11 @@ $(function() {
       }
 
       // Column titles
-      var energyConsumptionTitle = 'energy consumption (mWh)'; // Default column title
-      var co2EmissionsTitle = 'CO2e emissions (mg)';
+      var energyConsumptionTitle = 'Energy consumption (mWh)'; // Default column title
+      var co2EmissionsTitle = 'CO₂e emissions (mg)';
       if ($('#nf-table-humanreadable').val() == 'true') {
-        energyConsumptionTitle = 'energy consumption'; // Change the column title if the button is selected
-        co2EmissionsTitle = 'CO2e emissions';
+        energyConsumptionTitle = 'Energy consumption'; // Change the column title if the button is selected
+        co2EmissionsTitle = 'CO₂e emissions';
       }
 
       var table = $('#tasks_table').DataTable({
@@ -1198,7 +1198,7 @@ $(function() {
           { title: 'Time', data: 'time', type: 'num', render: make_time },
           { title: 'Carbon Intensity', data: 'ci', type: 'num', render: make_carbon_intensity },
           { title: 'Number of cores', data: 'cpus', type: 'num' },
-          { title: 'Power draw of a computing core', data: 'powerdrawCPU', type: 'num'},
+          { title: 'Power draw per core', data: 'powerdrawCPU', type: 'num'},
           { title: 'Core usage factor', data: 'cpuUsage', type: 'num', render: make_core_usage_factor },
           { title: 'Memory', data: 'memory', type: 'num', render: make_memory },
           { title: 'CPU model', data: 'cpu_model' },


### PR DESCRIPTION
## Summary
- Updates column names in the HTML tasks table for consistency and brevity (e.g., "power draw of a computing core" → "power draw per core").
- Improves overall readability of the table.

## Screenshots: 
### Before: 
<img width="701" alt="Screenshot 2025-07-07 at 13 27 09" src="https://github.com/user-attachments/assets/14073fb6-6b4a-45a9-809f-4d9ae5bcfe3d" />

### After: 
<img width="679" alt="Screenshot 2025-07-07 at 13 33 21" src="https://github.com/user-attachments/assets/a79053a3-96b5-4c60-ae24-a8b7dc51ed71" />

