### PR TITLE
Improve styling of collapsible element ("Without cashed tasks")

### DIFF
--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.html
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.html
@@ -130,8 +130,18 @@
 
       <details class="mt-5">
         <summary style="cursor: pointer;">
-          <span style="padding: 3px; border-radius: 10px; border: 2px solid #58bd9f; font-weight: bold">Without cached tasks:</span>
-        </summary>
+          <span style="
+            padding: 6px 12px;
+            border-radius: 8px;
+            border: 2px solid #badbcc;
+            background-color: #d1e7dd;
+            font-weight: bold;
+            color: #0f5132;
+            display: inline-block;
+          ">
+            Without cached tasks:
+          </span>
+        </summary>          
         <div class="d-flex flex-wrap mt-4 mb-5" style="gap: 1.5rem; margin-left: -0.75rem; margin-right: -0.75rem;">
           <div class="metric-card card p-1" style="width: 18%; text-align: center; flex: 1 1 200px; min-width: 200px;">
             <span class="metric">${co2_totals.co2e_non_cached}</span>

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintObserverTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintObserverTest.groovy
@@ -245,7 +245,7 @@ class CO2FootprintObserverTest extends Specification{
             234: '          ' +
                     "<span id=\"workflow_start\">${time.format('dd-MMM-YYYY HH:mm:ss')}</span>" +
                     " - <span id=\"workflow_complete\">${time.format('dd-MMM-YYYY HH:mm:ss')}</span>",
-            1293: '  window.options = [' +
+            1303: '  window.options = [' +
                     '{"option":"ci","value":"480.0"},'+
                     '{"option":"customCpuTdpFile","value":null},' +
                     '{"option":"ignoreCpuModel","value":"false"},' +

--- a/plugins/nf-co2footprint/src/testResources/file_checks.json
+++ b/plugins/nf-co2footprint/src/testResources/file_checks.json
@@ -1,7 +1,7 @@
 {
   "report_test.html": {
-    "checksum": "b7bab99c5919b1d1e5cea550bcd5f5b1",
-    "num_lines": 1298
+    "checksum": "7c8982d2dbc67726bf1882be983fa5ec",
+    "num_lines": 1308
   },
   "summary_test.txt": {
     "checksum": "43bf35b61c24500744b2be0021e7efff",

--- a/plugins/nf-co2footprint/src/testResources/report_test.html
+++ b/plugins/nf-co2footprint/src/testResources/report_test.html
@@ -282,8 +282,18 @@ footer a {
 
       <details class="mt-5">
         <summary style="cursor: pointer;">
-          <span style="padding: 3px; border-radius: 10px; border: 2px solid #58bd9f; font-weight: bold">Without cached tasks:</span>
-        </summary>
+          <span style="
+            padding: 6px 12px;
+            border-radius: 8px;
+            border: 2px solid #badbcc;
+            background-color: #d1e7dd;
+            font-weight: bold;
+            color: #0f5132;
+            display: inline-block;
+          ">
+            Without cached tasks:
+          </span>
+        </summary>         
         <div class="d-flex flex-wrap mt-4 mb-5" style="gap: 1.5rem; margin-left: -0.75rem; margin-right: -0.75rem;">
           <div class="metric-card card p-1" style="width: 18%; text-align: center; flex: 1 1 200px; min-width: 200px;">
             <span class="metric">6.53 g</span>


### PR DESCRIPTION
## Summary:
This PR improves the UI of the "without cashed tasks:" collapsible element by applying styles that visually match the html reports color scheme.

### Before: 
<img width="455" alt="Screenshot 2025-07-08 at 10 28 10" src="https://github.com/user-attachments/assets/330c62d5-9d0d-4b2c-b2ca-edf9dc773bdb" />

### After: 
<img width="484" alt="Screenshot 2025-07-08 at 10 27 53" src="https://github.com/user-attachments/assets/7889ff77-0d69-4402-9390-83d86a7961b1" />
