### PR TITLE
Feature: Better config modularity & alignment to nf-core config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+# Version 1.0.0-rc.2
+## Features:
+- Added support for nf-core style file definition
+
 # Version 1.0.0-rc.1
 ## Bug Fixes:
 - Version is `null` in many cases (parsed the wrong MANIFEST)

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -15,14 +15,17 @@ plugins {
   id 'nf-co2footprint@1.0.0-rc.1'
 }
 
-// Optional example config settings for CO₂ reporting:
-
-def co2_timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
-
 co2footprint {
-  traceFile = "${params.outdir}/pipeline_info/co2footprint_trace_${co2_timestamp}.txt"
-  summaryFile = "${params.outdir}/pipeline_info/co2footprint_summary_${co2_timestamp}.txt"
-  reportFile = "${params.outdir}/pipeline_info/co2footprint_report_${co2_timestamp}.html"
+  String co2_timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
+  trace {
+    file = "${params.outdir}/pipeline_info/co2footprint_trace_${co2_timestamp}.txt"
+  }
+  summary {
+    file = "${params.outdir}/pipeline_info/co2footprint_summary_${co2_timestamp}.txt"
+  }
+  report {
+    file = "${params.outdir}/pipeline_info/co2footprint_report_${co2_timestamp}.html"
+  }
   location = 'DE'                             // replace with your zone code
   emApiKey = secrets.EM_API_KEY               // set your API key as Nextflow secret with the name 'EM_API_KEY'
   pue = 1.3                                   // replace with PUE of your data center
@@ -99,12 +102,17 @@ plugins {
   id 'nf-co2footprint@1.0.0-rc.1'
 }
 
-def co2_timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
-
 co2footprint {
-    traceFile           = "${params.outdir}/co2footprint/co2footprint_trace_${co2_timestamp}.txt"
-    summaryFile         = "${params.outdir}/co2footprint/co2footprint_summary_${co2_timestamp}.txt"
-    reportFile          = "${params.outdir}/co2footprint/co2footprint_report_${co2_timestamp}.html"
+  String co2_timestamp = new java.util.Date().format('yyyy-MM-dd_HH-mm-ss')
+  trace {
+    file = "${params.outdir}/pipeline_info/co2footprint_trace_${co2_timestamp}.txt"
+  }
+  summary {
+    file = "${params.outdir}/pipeline_info/co2footprint_summary_${co2_timestamp}.txt"
+  }
+  report {
+    file = "${params.outdir}/pipeline_info/co2footprint_report_${co2_timestamp}.html"
+  }
     location            = 'DE'
     emApiKey            = secrets.EM_API_KEY
     pue                 = 1.3

--- a/docs/usage/parameters.md
+++ b/docs/usage/parameters.md
@@ -7,17 +7,43 @@ The following parameters are currently available:
 
 ## Output Files
 
-- **`traceFile`**  
-  Name of the `.txt` carbon footprint report containing the energy consumption, estimated CO₂ emission, and other relevant metrics for each task.  
-  **Default**: `co2footprint_trace_<timestamp>.txt`
+- **`trace`:**
+  A`.txt` carbon footprint report containing the energy consumption, estimated CO₂ emission, and other relevant metrics for each task.
+  - **`file`:**
+    Path & name of the trace file.
+    **Default**: `co2footprint_trace_<timestamp>.txt`
+  - **`enabled`:**
+    Whether the trace file should be constructed.
+    **Default**: `true`
+  - **`overwrite`:**
+    Whether a file with the same path should be overwritten.
+    **Default:** `false`
 
-- **`summaryFile`**  
-  Name of the `.txt` carbon footprint summary file containing the total energy consumption and total estimated CO₂ emission of the pipeline run.  
-  **Default**: `co2footprint_summary_<timestamp>.txt`
+- **`summary`:**
+  A `.txt` carbon footprint summary file containing the total energy consumption and total estimated CO₂ emission of the pipeline run.
+  - **`file`:**
+    Path & name of the summary file.  
+    **Default**: `co2footprint_summary_<timestamp>.txt`
+  - **`enabled`:** 
+    Whether the summary file should be constructed.
+    **Default**: `true`
+  - **`overwrite`:**
+    Whether a file with the same path should be overwritten.
+    **Default:** `false`
 
-- **`reportFile`**  
-  Name of the HTML report containing information about the entire carbon footprint, overview plots, and more detailed task-specific metrics.  
-  **Default**: `co2footprint_report_<timestamp>.html`
+- **`report`:**
+  A HTML report containing information about the entire carbon footprint, overview plots, and more detailed task-specific metrics.
+  - **`file`:**
+    Path & name of the report file.
+    **Default**: `co2footprint_report_<timestamp>.html`
+  - **`enabled`:** Whether the report file should be constructed.
+    **Default**: `true`
+  - **`overwrite`:**
+    Whether a file with the same path should be overwritten.
+    **Default:** `false`
+  - **`maxTasks`:**
+    Maximum number of reported tasks in the respective table. The table mirrors the trace file, which is not affected by this upper limit. Note: A larger number may lead to a larger and slower report document.
+    **Default**: `10_000`
 
 ## Location & Carbon Intensity
 

--- a/docs/usage/parameters.md
+++ b/docs/usage/parameters.md
@@ -7,42 +7,45 @@ The following parameters are currently available:
 
 ## Output Files
 
-- **`trace`:**
-  A`.txt` carbon footprint report containing the energy consumption, estimated CO₂ emission, and other relevant metrics for each task.
-  - **`file`:**
-    Path & name of the trace file.
-    **Default**: `co2footprint_trace_<timestamp>.txt`
-  - **`enabled`:**
-    Whether the trace file should be constructed.
-    **Default**: `true`
-  - **`overwrite`:**
-    Whether a file with the same path should be overwritten.
+**`trace`:**  
+A .txt carbon footprint report with per-task energy use, CO₂ estimates, and other key metrics, similar to a standard Nextflow trace file.
+
+  - **`file`**  
+    Path & name of the trace file.  
+    **Default:** `co2footprint_trace_<timestamp>.txt`
+  - **`enabled`**  
+    Whether the trace file should be constructed.  
+    **Default:** `true`
+  - **`overwrite`**  
+    Whether a file with the same path should be overwritten.  
     **Default:** `false`
 
-- **`summary`:**
-  A `.txt` carbon footprint summary file containing the total energy consumption and total estimated CO₂ emission of the pipeline run.
-  - **`file`:**
+**`summary`:**  
+  A .txt carbon footprint summary file containing the total energy consumption and total estimated CO₂ emission of the pipeline run as well as illustrative equivalence metrics.
+  
+  - **`file`:**  
     Path & name of the summary file.  
     **Default**: `co2footprint_summary_<timestamp>.txt`
-  - **`enabled`:** 
-    Whether the summary file should be constructed.
+  - **`enabled`:**  
+    Whether the summary file should be constructed.  
     **Default**: `true`
-  - **`overwrite`:**
-    Whether a file with the same path should be overwritten.
+  - **`overwrite`:**  
+    Whether a file with the same path should be overwritten.  
     **Default:** `false`
 
-- **`report`:**
-  A HTML report containing information about the entire carbon footprint, overview plots, and more detailed task-specific metrics.
+**`report`:**  
+  A HTML report summarizing the overall carbon footprint of the pipeline run, including equivalence metrics, visual overview plots, and detailed per-task metrics.
+  
   - **`file`:**
-    Path & name of the report file.
+    Path & name of the report file.  
     **Default**: `co2footprint_report_<timestamp>.html`
-  - **`enabled`:** Whether the report file should be constructed.
+  - **`enabled`:** Whether the report file should be constructed.  
     **Default**: `true`
   - **`overwrite`:**
-    Whether a file with the same path should be overwritten.
+    Whether a file with the same path should be overwritten.  
     **Default:** `false`
   - **`maxTasks`:**
-    Maximum number of reported tasks in the respective table. The table mirrors the trace file, which is not affected by this upper limit. Note: A larger number may lead to a larger and slower report document.
+    Maximum number of reported tasks in the respective table. The table mirrors the trace file, which is not affected by this upper limit. Note: A larger number may lead to a larger and slower report document.  
     **Default**: `10_000`
 
 ## Location & Carbon Intensity

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -24,8 +24,8 @@ import java.nio.file.Paths
  *
  * Example usage in config:
  * co2footprint {
- *     trace = [file: "co2footprint_trace.txt"]
- *     summary = [file: "co2footprint_summary.txt"]
+ *     trace = {file = "co2footprint_trace.txt"}
+ *     summary = {file = "co2footprint_trace.txt"}
  *     ci = 300
  *     pue = 1.4
  *     powerdrawMem = 0.67
@@ -39,6 +39,10 @@ class CO2FootprintConfig extends BaseConfig {
     private final String suffix = "_${TraceHelper.launchTimestampFmt()}"
     private final List<String> supportedMachineTypes = ['local', 'compute cluster', 'cloud']
 
+    /**
+     * Define all configurable parameters used in CO₂ footprint tracking.
+     * Called once during construction.
+     */
     void initializeParameters() {
         addParameter(
                 ['trace', new TraceFileConfig([:], suffix)],

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -24,8 +24,8 @@ import java.nio.file.Paths
  *
  * Example usage in config:
  * co2footprint {
- *     traceFile = "co2footprint_trace.txt"
- *     summaryFile = "co2footprint_summary.txt"
+ *     trace = [file: "co2footprint_trace.txt"]
+ *     summary = [file: "co2footprint_summary.txt"]
  *     ci = 300
  *     pue = 1.4
  *     powerdrawMem = 0.67

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -39,10 +39,12 @@ class CO2FootprintConfig extends BaseConfig {
     void initializeParameters() {
         addParameter(
                 ['traceFile', { -> "co2footprint_trace_${timestamp}.txt"}],
-                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'trace file'])
+                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'trace file']
+        )
         addParameter(
                 ['summaryFile', { -> "co2footprint_summary_${timestamp}.txt"}],
-                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'summary file'])
+                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'summary file']
+        )
         addParameter(
                 ['reportFile', { -> "co2footprint_report_${timestamp}.html"}],
                 [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'report file']
@@ -114,11 +116,11 @@ class CO2FootprintConfig extends BaseConfig {
      * @param processMap  Map with process/executor info
      */
     CO2FootprintConfig(Map<String, Object> configMap, TDPDataMatrix cpuData, CIDataMatrix ciData, Map<String, Object> processMap) {
-        // Initialization of the Configuration in order: Methods & Constants through super(), Parameters, Mapping, Initializing rest to default with mapping
-        super()
-        initializeParameters()
-        this.parameters.fill(configMap)
-        initialize()
+        // Initialization of the Configuration in order:
+        super()                     // - Methods & Constants through super()
+        initializeParameters()      // - Parameters
+        fill(configMap)             // - Mapping
+        setDefaults([], false)  // - Initializing rest with default (function)
 
 
         // Determine the carbon intensity (CI) value

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -7,6 +7,9 @@ import nextflow.co2footprint.DataContainers.DataMatrix
 import nextflow.co2footprint.DataContainers.CIDataMatrix
 import nextflow.co2footprint.DataContainers.CIValueComputer
 import nextflow.co2footprint.DataContainers.TDPDataMatrix
+import nextflow.co2footprint.FileCreators.ReportFileConfig
+import nextflow.co2footprint.FileCreators.SummaryFileConfig
+import nextflow.co2footprint.FileCreators.TraceFileConfig
 import nextflow.trace.TraceHelper
 
 import java.nio.file.Path
@@ -33,21 +36,21 @@ import java.nio.file.Paths
 @Slf4j
 class CO2FootprintConfig extends BaseConfig {
     // Helper variables
-    private final String timestamp = TraceHelper.launchTimestampFmt()
+    private final String suffix = "_${TraceHelper.launchTimestampFmt()}"
     private final List<String> supportedMachineTypes = ['local', 'compute cluster', 'cloud']
 
     void initializeParameters() {
         addParameter(
-                ['traceFile', { -> "co2footprint_trace_${timestamp}.txt"}],
-                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'trace file']
+                ['trace', new TraceFileConfig([:], suffix)],
+                [returnType: TraceFileConfig, allowedTypes: [TraceFileConfig], description: 'trace file']
         )
         addParameter(
-                ['summaryFile', { -> "co2footprint_summary_${timestamp}.txt"}],
-                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'summary file']
+                ['summary', new SummaryFileConfig([:], suffix)],
+                [returnType: SummaryFileConfig, allowedTypes: [SummaryFileConfig], description: 'summary file']
         )
         addParameter(
-                ['reportFile', { -> "co2footprint_report_${timestamp}.html"}],
-                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'report file']
+                ['report', new ReportFileConfig([:], suffix)],
+                [returnType: ReportFileConfig, allowedTypes: [ReportFileConfig], description: 'report file']
         )
         addParameter(
                 ['location'],
@@ -92,9 +95,9 @@ class CO2FootprintConfig extends BaseConfig {
     }
 
     // Getter methods for config values
-    String getTraceFile() { get('traceFile') }
-    String getSummaryFile() { get('summaryFile') }
-    String getReportFile() { get('reportFile') }
+    TraceFileConfig getTrace() { get('trace') as TraceFileConfig }
+    SummaryFileConfig getSummary() { get('summary') as SummaryFileConfig }
+    ReportFileConfig getReport() { get('report') as ReportFileConfig }
     String getLocation() { get('location') }
     Double getCi() { evaluate('ci') }
     Double getCiMarket() { evaluate('ciMarket') }
@@ -234,9 +237,9 @@ class CO2FootprintConfig extends BaseConfig {
      */
     SortedMap<String, Object> collectOutputFileOptions() {
         return [
-                "traceFile": traceFile,
-                "summaryFile": summaryFile,
-                "reportFile": reportFile
+                "trace": trace.getEntries(),
+                "summary": summary.getEntries(),
+                "report": report.getEntries()
         ].sort() as SortedMap
     }
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -2,6 +2,7 @@ package nextflow.co2footprint
 
 
 import groovy.util.logging.Slf4j
+import nextflow.co2footprint.Config.BaseConfig
 import nextflow.co2footprint.DataContainers.DataMatrix
 import nextflow.co2footprint.DataContainers.CIDataMatrix
 import nextflow.co2footprint.DataContainers.CIValueComputer

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -119,8 +119,8 @@ class CO2FootprintConfig extends BaseConfig {
         // Initialization of the Configuration in order:
         super()                     // - Methods & Constants through super()
         initializeParameters()      // - Parameters
+        setDefaults([], false)  // - Initializing the default (function)
         fill(configMap)             // - Mapping
-        setDefaults([], false)  // - Initializing rest with default (function)
 
 
         // Determine the carbon intensity (CI) value

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -8,6 +8,8 @@ import nextflow.co2footprint.DataContainers.CIDataMatrix
 import nextflow.co2footprint.DataContainers.CIValueComputer
 import nextflow.co2footprint.DataContainers.TDPDataMatrix
 import nextflow.trace.TraceHelper
+
+import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
@@ -29,55 +31,78 @@ import java.nio.file.Paths
  * @author Júlia Mir Pedrol <mirp.julia@gmail.com>, Sabrina Krakau <sabrinakrakau@gmail.com>
  */
 @Slf4j
-class CO2FootprintConfig {
-
-    // Configuration parameters (can be set in Nextflow config)
-    private String  timestamp = TraceHelper.launchTimestampFmt()
-    private String  traceFile = "co2footprint_trace_${timestamp}.txt"
-    private String  summaryFile = "co2footprint_summary_${timestamp}.txt"
-    private String  reportFile = "co2footprint_report_${timestamp}.html"
-    private String  location = null
-    private def     ci = null                       // CI: carbon intensity
-    private def     ciMarket = null                 // Market based CI
-    private String  emApiKey = null                   // API key for electricityMaps
-    private Double  pue = null                      // PUE: power usage effectiveness efficiency, coefficient of the data centre
-    private Double  powerdrawMem = 0.3725           // Power draw of memory [W per GB]
-    private Boolean ignoreCpuModel = false
-    private Double  powerdrawCpuDefault = null
-    private String  customCpuTdpFile = null
-    private String  machineType = null              // Type of computer on which the workflow is run ['local', 'compute cluster', '']
-
-    // Supported machine types
+class CO2FootprintConfig extends BaseConfig {
+    // Helper variables
+    private final String timestamp = TraceHelper.launchTimestampFmt()
     private final List<String> supportedMachineTypes = ['local', 'compute cluster', 'cloud']
 
+    void initializeParameters() {
+        addParameter(
+                ['traceFile', { -> "co2footprint_trace_${timestamp}.txt"}],
+                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'trace file'])
+        addParameter(
+                ['summaryFile', { -> "co2footprint_summary_${timestamp}.txt"}],
+                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'summary file'])
+        addParameter(
+                ['reportFile', { -> "co2footprint_report_${timestamp}.html"}],
+                [returnType: String, allowedTypes: [String, Closure<GString>, GString, Path], description: 'report file']
+        )
+        addParameter(
+                ['location'],
+                [returnType: String, description: 'location code']
+        )
+        addParameter(
+                ['ci'],
+                [allowedTypes: [Double, BigDecimal, Closure<Double>], description: 'location-based carbon intensity']
+        )
+        addParameter(
+                ['ciMarket'],
+                [allowedTypes: [Double, BigDecimal, Closure<Double>], description: 'market-based carbon intensity']
+        )
+        addParameter(
+                ['emApiKey'],
+                [returnType: String, description: 'API key for Electricity Maps']
+        )
+        addParameter(
+                ['pue'],
+                [returnType: Double, allowedTypes: [Double, BigDecimal], description: 'power usage effectiveness efficiency, coefficient of the data centre']
+        )
+        addParameter(
+                ['powerdrawMem', 0.3725],
+                [returnType: Double, allowedTypes: [Double, BigDecimal], description: 'Consumption of power by the memory [W/GB]']
+        )
+        addParameter(
+                ['ignoreCpuModel', false],
+                [returnType: Boolean, description: 'Set to use the default TDP']
+        )
+        addParameter(
+                ['powerdrawCpuDefault'],
+                [returnType: Double, allowedTypes: [Double, BigDecimal], description: 'Consumption of power by the CPU [W/core]']
+        )
+        addParameter(
+                ['customCpuTdpFile'],
+                [returnType: String, description: 'Path to a custom TDP file in CSV format']
+        )
+        addParameter(
+                ['machineType'],
+                [returnType: String, description: 'Type of computer on which the workflow is run [\'local\', \'compute cluster\', \'cloud\']']
+        )
+    }
+
     // Getter methods for config values
-    String getTimestamp() { timestamp }
-    String getTraceFile() { traceFile }
-    String getSummaryFile() { summaryFile }
-    String getReportFile() { reportFile }
-    String getLocation() { location }
-
-    /**
-     * Returns the carbon intensity value.
-     * If set as a closure (for real-time API), invokes it to get the current value.
-     */
-    Double getCi() {
-        (ci instanceof Closure) ? (ci as Closure<Double>)() : ci
-    }
-
-    /**
-     * Returns the personal energy mix carbon intensity value.
-     * If set as a closure (in case user defined a function for it in the config), invokes it to get the current value.
-     */
-    Double getCiMarket() {
-        (ciMarket instanceof Closure) ? (ciMarket as Closure<Double>)() : ciMarket
-    }
-    Double getPue() { pue }
-    Boolean getIgnoreCpuModel() { ignoreCpuModel }
-    Double getPowerdrawCpuDefault() { powerdrawCpuDefault }
-    Double getPowerdrawMem() { powerdrawMem }
-    String getCustomCpuTdpFile() { customCpuTdpFile }
-    String getMachineType()  { machineType }
+    String getTraceFile() { get('traceFile') }
+    String getSummaryFile() { get('summaryFile') }
+    String getReportFile() { get('reportFile') }
+    String getLocation() { get('location') }
+    Double getCi() { evaluate('ci') }
+    Double getCiMarket() { evaluate('ciMarket') }
+    String getEmApiKey() { get('emApiKey')}
+    Double getPue() { get('pue') as Double }
+    Boolean getIgnoreCpuModel() { get('ignoreCpuModel') }
+    Double getPowerdrawCpuDefault() { get('powerdrawCpuDefault') as Double }
+    Double getPowerdrawMem() { get('powerdrawMem') as Double }
+    String getCustomCpuTdpFile() { get('customCpuTdpFile') }
+    String getMachineType()  { get('machineType') }
 
     /**
      * Loads configuration from a map and sets up defaults and fallbacks.
@@ -89,30 +114,23 @@ class CO2FootprintConfig {
      * @param processMap  Map with process/executor info
      */
     CO2FootprintConfig(Map<String, Object> configMap, TDPDataMatrix cpuData, CIDataMatrix ciData, Map<String, Object> processMap) {
-        // Ensure configMap is not null
-        configMap ?= [:]
+        // Initialization of the Configuration in order: Methods & Constants through super(), Parameters, Mapping, Initializing rest to default with mapping
+        super()
+        initializeParameters()
+        this.parameters.fill(configMap)
+        initialize()
 
-        // Assign values from map to config
-        configMap.each { name, value ->
-            if (this.hasProperty(name)) {
-                this.setProperty(name, value)
-            } else {
-                // Log warning and skip the key
-                log.warn("Skipping unknown configuration key: '${name}'")
-            }
-        }
 
         // Determine the carbon intensity (CI) value
         if (ci == null) {
-
             CIValueComputer ciValueComputer = new CIValueComputer(emApiKey, location, ciData)
             // ci is either set to a Closure (in case the electricity maps API is used) or to a Double (in the other cases)
             // The closure is invoked each time the CO2 emissions are calculated (for each task) to make a new API call to update the real time ci value.
-            ci = ciValueComputer.computeCI()
+            set('ci', ciValueComputer.computeCI())
         }
 
         // Sets machineType and pue based on the executor if machineType is not already set
-        if (this.machineType == null) {
+        if (machineType == null) {
             setMachineTypeAndPueFromExecutor(processMap?.get('executor') as String)
         }
 
@@ -127,21 +145,20 @@ class CO2FootprintConfig {
         }
 
         // Assign PUE if not already given
-        pue ?= switch (machineType) {
+        setEmpty('pue', switch (machineType) {
             case 'local' -> 1.0
             case 'compute cluster' -> 1.67
             case 'cloud' -> 1.56  // source: (https://datacenter.uptimeinstitute.com/rs/711-RIA-145/images/2024.GlobalDataCenterSurvey.Report.pdf)
             default -> 1.0 // Fallback PUE (assigned if machineType is null)
-        }
+        })
 
         // Set fallback CPU model based on machine type
         if (machineType) {
             if (supportedMachineTypes.contains(machineType)) {
-                cpuData.fallbackModel = "default $machineType" as String
+                cpuData.fallbackModel = "default ${machineType}" as String
             }
             else {
-                final String message = "machineType '${machineType}' is not supported." +
-                        "Please chose one of ${supportedMachineTypes}."
+                final String message = "machineType '${machineType}' is not supported. Please chose one of ${supportedMachineTypes}."
                 log.error(message)
                 throw new IllegalArgumentException(message)
             }
@@ -182,8 +199,8 @@ class CO2FootprintConfig {
             // Check if matrix contains the required columns
             machineTypeMatrix.checkRequiredColumns(['machineType', 'pue'])
             if (machineTypeMatrix.rowIndex.containsKey(executor)) {
-                this.machineType = machineTypeMatrix.get(executor, 'machineType') as String
-                this.pue ?= machineTypeMatrix.get(executor, 'pue') as Double // assign pue only if not already set
+                set('machineType',  machineTypeMatrix.get(executor, 'machineType') as String)
+                setEmpty('pue', machineTypeMatrix.get(executor, 'pue') as Double)
             }
             else {
                 log.warn(

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintFactory.groovy
@@ -115,16 +115,20 @@ class CO2FootprintFactory implements TraceObserverFactory {
                 session.config.navigate('process') as Map
         )
 
-        // Define list of observers
-        final ArrayList<TraceObserver> result = [
-            new CO2FootprintObserver(
-                session,
-                this.pluginVersion,
-                config,
-                new CO2FootprintComputer(this.tdpDataMatrix, config)
-            )
-        ]
+        // Define observer
+        CO2FootprintObserver observer = CO2FootprintObserver.initialize(
+            session,
+            this.pluginVersion,
+            config,
+            new CO2FootprintComputer(this.tdpDataMatrix, config)
+        )
 
-        return result
+        // Define list of observers
+        if (observer) {
+            return [observer] as ArrayList<TraceObserver>
+        } else {
+            log.error('No trace observer defined. Exiting plugin.')
+            return []
+        }
     }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
@@ -79,10 +79,7 @@ class CO2FootprintObserver implements TraceObserver {
             CO2FootprintComputer co2FootprintComputer
     ){
         // See if any file is enabled
-        List<String> fileNames = ['trace', 'summary', 'report']
-        Boolean makeObserver = fileNames.collect({ String fileName -> config.get(fileName).getEnabled() }).any()
-
-        if (makeObserver) {
+        if (['trace', 'summary', 'report'].any { String fileEntry -> config.get(fileEntry).getEnabled() }) {
             return new CO2FootprintObserver(session, version, config, co2FootprintComputer)
         } else {
             log.error('All output files are disabled (`enabled=false`). Observer not created.')

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
@@ -4,12 +4,11 @@ import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 
 import nextflow.Session
-import nextflow.co2footprint.Records.CO2EquivalencesRecord
 import nextflow.co2footprint.Records.CO2Record
 import nextflow.co2footprint.Records.CO2RecordAggregator
-import nextflow.co2footprint.FileCreators.CO2FootprintReport
-import nextflow.co2footprint.FileCreators.CO2FootprintSummary
-import nextflow.co2footprint.FileCreators.CO2FootprintTrace
+import nextflow.co2footprint.FileCreators.ReportFile
+import nextflow.co2footprint.FileCreators.SummaryFile
+import nextflow.co2footprint.FileCreators.TraceFile
 import nextflow.processor.TaskHandler
 import nextflow.processor.TaskId
 import nextflow.processor.TaskProcessor
@@ -44,9 +43,9 @@ class CO2FootprintObserver implements TraceObserver {
     private Map<String, Path> paths = [:]
 
     // Output file objects
-    private CO2FootprintTrace co2eTraceFile
-    private CO2FootprintSummary co2eSummaryFile
-    private CO2FootprintReport co2eReportFile
+    private TraceFile co2eTraceFile
+    private SummaryFile co2eSummaryFile
+    private ReportFile co2eReportFile
 
     // Overwrite existing files if true
     private boolean overwrite
@@ -153,12 +152,12 @@ class CO2FootprintObserver implements TraceObserver {
             }
         }
 
-        co2eTraceFile = new CO2FootprintTrace(paths['co2eTrace'], overwrite)
+        co2eTraceFile = new TraceFile(paths['co2eTrace'], overwrite)
         co2eTraceFile.create()
 
-        co2eSummaryFile = new CO2FootprintSummary(paths['co2eSummary'], overwrite)
+        co2eSummaryFile = new SummaryFile(paths['co2eSummary'], overwrite)
 
-        co2eReportFile = new CO2FootprintReport(paths['co2eReport'], overwrite, maxTasks)
+        co2eReportFile = new ReportFile(paths['co2eReport'], overwrite, maxTasks)
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
@@ -105,4 +105,13 @@ class BaseConfig {
      * @return Whether the property exists in the config instance
      */
     Boolean has(String name) { return parameters.has(name) }
+
+    /**
+     * Get the current parameter entries.
+     *
+     * @return The entries as a Map
+     */
+    Map<String, Object> getEntries() {
+        return parameters.getEntries()
+    }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
@@ -8,8 +8,15 @@ import groovy.util.logging.Slf4j
  */
 @Slf4j
 class BaseConfig {
+    // The internal ConfigParameters object that holds all configuration data.
     final private ConfigParameters parameters
 
+    /**
+     * Constructor for BaseConfig.
+     *
+     * @param parameters Either an existing ConfigParameters object or a list/set of parameter names.
+     * @param configMap Optional map of parameter names and values to initialize immediately.
+     */
     BaseConfig(def parameters=[], Map<String, Object> configMap=null) {
         // Initializes parameters
         if (parameters instanceof ConfigParameters) { this.parameters = parameters  }
@@ -18,14 +25,14 @@ class BaseConfig {
         // Sets defaults if not set by configure / fill
         setDefaults()
 
-        // Adds mapped entries to config
+        // Add values from provided config map, if any
         if (configMap != null) { fill(configMap) }
     }
 
     ConfigParameters getParameters() { parameters }
 
     /**
-     * Add a Config Parameter with args and kwArgs.
+     * Adds a new configuration parameter using positional and keyword arguments.
      *
      * @param args Argument list to be considered first
      * @param keywordArgs Keyword arguments to complement the argument list.
@@ -44,7 +51,7 @@ class BaseConfig {
     }
 
     /**
-     * Initialize the parameters.
+     * Initializes all registered parameters with their default values.
      *
      * @param args Arguments for default function, default `null` skips function initialization
      * @param overwrite Whether to overwrite the previously set value
@@ -54,7 +61,7 @@ class BaseConfig {
     }
 
     /**
-     * Initialize the parameters.
+     * Initializes a specific parameter with a default value.
      *
      * @param name Name of the parameter
      * @param value Value of the parameter
@@ -73,7 +80,7 @@ class BaseConfig {
     def get(String name) { return parameters.get(name) }
 
     /**
-     * Evaluate the parameter if it is a function.
+     * Evaluate the parameter if it is a function or closure..
      *
      * @param name Name of the parameter
      * @return The evaluated value of the key
@@ -99,10 +106,10 @@ class BaseConfig {
     }
 
     /**
-     * Does the config have this parameter?
+     * Checks if a parameter with the given name exists in the configuration.
      *
-     * @param name Name of the parameter
-     * @return Whether the property exists in the config instance
+     * @param name Name of the parameter.
+     * @return true if the parameter exists, false otherwise.
      */
     Boolean has(String name) { return parameters.has(name) }
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
@@ -1,0 +1,98 @@
+package nextflow.co2footprint.Config
+
+import groovy.util.logging.Slf4j
+
+/**
+ * Base class for configurations
+ */
+@Slf4j
+class BaseConfig {
+    protected HashMap<String, Object> constants
+    final private HashMap<String, ConfigParameter> parameters
+
+    BaseConfig(Set<ConfigParameter> parameters, Map<String, Object> configMap, HashMap<String, Object> constants=[:]) {
+        this.constants = constants
+        this.parameters = parameters.collectEntries { ConfigParameter configParameter ->
+            [configParameter.name, configParameter]
+        } as HashMap<String, ConfigParameter>
+
+        // Ensure configMap is not null
+        configMap ?= [:]
+
+        // Assign values from map to config
+        configMap.each { name, value -> configure(name, value)}
+    }
+
+    HashMap<String, Object> getConstants() { constants }
+    HashMap<String, ConfigParameter> getParameters() { parameters }
+
+
+    /**
+     * Configure a parameter of the configuration
+     *
+     * @param name Name of the parameter
+     * @param value Value of the parameter
+     */
+    void configure(String name, def value) {
+        if (has(name)) {
+            if (get(name) == null || value in get(name))
+            set(name, value)
+        } else {
+            // Log warning and skip the key
+            log.warn("Skipping unknown configuration key: '${name}'")
+        }
+    }
+
+    /**
+     * Get value of the parameter.
+     *
+     * @param name Name of the parameter
+     * @return The value to the key
+     */
+    def get(String name) {
+        return parameters.get(name).get()
+    }
+
+    /**
+     * Evaluate the parameter if it is a function.
+     *
+     * @param name Name of the parameter
+     * @return The evaluated value of the key
+     */
+    <T> T evaluate(String name) {
+        T value = parameters.get(name).evaluate()
+        return value
+    }
+
+    /**
+     * Set value of the parameter.
+     *
+     * @param name Name of the parameter
+     * @param value Value to be set to
+     */
+    void set(String name, def value) {
+        ConfigParameter parameter = parameters.get(name)
+        parameter.set(value)
+    }
+
+    /**
+     * Does the config have this parameter?
+     *
+     * @param name Name of the parameter
+     * @return Whether the property exists in the config instance
+     */
+    Boolean has(String name) {
+        return parameters.containsKey(name)
+    }
+
+    /**
+     * Get the current parameter entries.
+     *
+     * @return The entries as a Map
+     */
+    Map<String, Object> getEntries() {
+        return getParameters().collectEntries { String name, ConfigParameter configParameter ->
+            [name, configParameter.get()]
+        }
+    }
+}

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
@@ -11,11 +11,15 @@ class BaseConfig {
     final private ConfigParameters parameters
 
     BaseConfig(def parameters=[], Map<String, Object> configMap=null) {
+        // Initializes parameters
         if (parameters instanceof ConfigParameters) { this.parameters = parameters  }
         else { this.parameters = new ConfigParameters(parameters as Set) }
 
-        if (configMap != null) { this.parameters.fill(configMap) }
-        initialize()
+        // Adds mapped entries to config
+        if (configMap != null) { fill(configMap) }
+
+        // Sets defaults if not set by configure / fill
+        setDefaults()
     }
 
     ConfigParameters getParameters() { parameters }
@@ -31,12 +35,34 @@ class BaseConfig {
     }
 
     /**
+     * Fills the parameters with the mapped entries
+     *
+     * @param configMap Map with entries for the config
+     */
+    void fill(Map<String, Object> configMap) {
+        parameters.fill(configMap)
+    }
+
+    /**
+     * Initialize the parameters.
+     *
+     * @param args Arguments for default function, default `null` skips function initialization
+     * @param overwrite Whether to overwrite the previously set value
+     */
+    void setDefaults(List<Object> args=null, boolean overwrite=false) {
+        parameters.setDefaults(args, overwrite)
+    }
+
+    /**
      * Initialize the parameters.
      *
      * @param name Name of the parameter
      * @param value Value of the parameter
+     * @param overwrite Whether to overwrite the previously set value
      */
-    void initialize() { parameters.initialize() }
+    void setDefault(String name, List<Object> args, boolean overwrite=false) {
+        parameters.setDefault(name, args, overwrite)
+    }
 
     /**
      * Get value of the parameter.

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/BaseConfig.groovy
@@ -15,11 +15,11 @@ class BaseConfig {
         if (parameters instanceof ConfigParameters) { this.parameters = parameters  }
         else { this.parameters = new ConfigParameters(parameters as Set) }
 
-        // Adds mapped entries to config
-        if (configMap != null) { fill(configMap) }
-
         // Sets defaults if not set by configure / fill
         setDefaults()
+
+        // Adds mapped entries to config
+        if (configMap != null) { fill(configMap) }
     }
 
     ConfigParameters getParameters() { parameters }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
@@ -93,10 +93,17 @@ class ConfigEntry {
      */
     void set(def value) {
         if (returnType in BaseConfig && !(value in BaseConfig)) {
-            value = returnType.newInstance(value)
+            if (this.value in BaseConfig) {
+                this.value.fill(value)
+            }
+            else {
+                value = returnType.newInstance(value)
+            }
         }
-        checkType(value)
-        this.value = value
+        else {
+            checkType(value)
+            this.value = value
+        }
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
@@ -6,7 +6,7 @@ package nextflow.co2footprint.Config
 class ConfigEntry {
     private final String name
     private final defaultValue
-    private final SequencedCollection<Class> allowedTypes
+    private final List<Class> allowedTypes
     private final Class returnType
     private final String description
     private def value
@@ -15,7 +15,7 @@ class ConfigEntry {
     ConfigEntry(
         String name,
         def defaultValue=null,
-        SequencedCollection<Class> allowedTypes=null,
+        List<Class> allowedTypes=null,
         Class returnType=null,
         String description=null
     ) {
@@ -33,8 +33,7 @@ class ConfigEntry {
                 [Object]
             }
         }()
-
-        this.returnType = returnType ?: this.allowedTypes.getFirst()
+        this.returnType = returnType ?: this.allowedTypes[0]
 
         this.description = description
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
@@ -45,26 +45,6 @@ class ConfigEntry {
     String getReturnType() { returnType }
 
     /**
-     * Initialize the value with the given default (function).
-     * Calling the default function will not initialize functions.
-     * To initialize defaultValue functions without arguments, args needs to be set to [].
-     *
-     * @param args Arguments for the default function
-     */
-    void initialize(List<?> args=null, boolean initialized=this.initialized) {
-        if(!initialized) {
-            if (args != null && defaultValue instanceof Runnable) {
-                set(defaultValue(*args))
-                this.initialized = true
-            }
-            else{
-                set(defaultValue)
-                this.initialized = true
-            }
-        }
-    }
-
-    /**
      * Check whether the value is of an allowed type.
      *
      * @param value Value to be checked
@@ -77,6 +57,38 @@ class ConfigEntry {
     }
 
     /**
+     * Initialize the value with the given default (function).
+     * Calling the default function will not initialize functions.
+     * To initialize defaultValue functions without arguments, args needs to be set to [].
+     *
+     * @param args Arguments for the default function
+     * @param overwrite Whether to overwrite the previously set value
+     */
+    void setDefault(List<Object> args=null, boolean overwrite=false) {
+        boolean doSet = !initialized ||overwrite
+        if(doSet) {
+            if (args != null && defaultValue instanceof Runnable) {
+                set(defaultValue(*args))
+            }
+            else{
+                set(defaultValue)
+            }
+            this.initialized = true
+        }
+    }
+
+    /**
+     * Configure the value for the first time. Sets initialized = true to avoid double initialization.
+     *
+     * @param value Sets this value
+     */
+    void configure(def value) {
+        checkType(value)
+        this.value = value
+        this.initialized = true
+    }
+
+    /**
      * Set the value.
      *
      * @param value
@@ -85,18 +97,6 @@ class ConfigEntry {
         checkType(value)
         this.value = value
     }
-
-    /**
-     * Set the value.
-     *
-     * @param value
-     */
-    void configure(def value) {
-        checkType(value)
-        this.value = value
-        this.initialized = true
-    }
-
     /**
      * Get the current value.
      *

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
@@ -22,17 +22,22 @@ class ConfigEntry {
         this.name = name
         this.defaultValue = defaultValue
 
-        this.allowedTypes = {
-            if (allowedTypes) {
-                allowedTypes
-            } else if (returnType != null) {
-                [returnType]
-            } else if (defaultValue != null && !(defaultValue instanceof Runnable)) {
-                [defaultValue.getClass()]
-            } else {
-                [Object]
-            }
-        }()
+        // Determine allowedTypes based on priority:
+        if (allowedTypes != null) {
+            // 1. Use explicitly provided allowedTypes
+            this.allowedTypes = allowedTypes
+        } else if (returnType != null) {
+            // 2. If returnType is provided, use it as the only allowed type
+            this.allowedTypes = [returnType]
+        } else if (defaultValue != null && !(defaultValue instanceof Runnable)) {
+            // 3. If defaultValue exists and is not a Runnable, infer its type
+            this.allowedTypes = [defaultValue.getClass()]
+        } else {
+            // 4. Fallback: allow any type
+            this.allowedTypes = [Object]
+        }
+
+        // Fall back to the first allowed type, if no return type is explicitly given
         this.returnType = returnType ?: this.allowedTypes[0]
 
         this.description = description

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
@@ -83,8 +83,7 @@ class ConfigEntry {
      * @param value Sets this value
      */
     void configure(def value) {
-        checkType(value)
-        this.value = value
+        set(value)
         this.initialized = true
     }
 
@@ -94,6 +93,9 @@ class ConfigEntry {
      * @param value
      */
     void set(def value) {
+        if (returnType in BaseConfig && !(value in BaseConfig)) {
+            value = returnType.newInstance(value)
+        }
         checkType(value)
         this.value = value
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
@@ -3,7 +3,7 @@ package nextflow.co2footprint.Config
 /**
  * A holder class for parameters in a config.
  */
-class ConfigParameter {
+class ConfigEntry {
     private final String name
     private final defaultValue
     private final SequencedCollection<Class> allowedTypes
@@ -12,7 +12,7 @@ class ConfigParameter {
     private def value
     private boolean initialized = false
 
-    ConfigParameter(
+    ConfigEntry(
         String name,
         def defaultValue=null,
         SequencedCollection<Class> allowedTypes=null,

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigEntry.groovy
@@ -97,6 +97,7 @@ class ConfigEntry {
         checkType(value)
         this.value = value
     }
+
     /**
      * Get the current value.
      *

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
@@ -1,0 +1,143 @@
+package nextflow.co2footprint.Config
+
+import groovy.util.logging.Slf4j
+
+@Slf4j
+class ConfigParameters {
+    final private HashMap<String, ConfigParameter> vault
+
+    ConfigParameters(Set<ConfigParameter> configurationParameters=[]) {
+        this.vault = configurationParameters.collectEntries { ConfigParameter configParameter ->
+            [configParameter.name, configParameter]
+        } as HashMap<String, ConfigParameter>
+    }
+
+    /**
+     * Add a Config Parameter to the vault.
+     *
+     * @param parameter Constructed parameter that is added
+     */
+    void add(ConfigParameter parameter) {
+        this.vault.put(parameter.getName(), parameter)
+    }
+
+    /**
+     * Add a Config Parameter with args and kwArgs.
+     *
+     * @param args Argument list to be considered first
+     * @param keywordArgs Keyword arguments to complement the argument list.
+     */
+    void add(List<?> args, Map<String, ?> keywordArgs=[:]) {
+        List<String> optionOrder = ['name', 'defaultValue', 'allowedTypes', 'returnType', 'description']
+        args.addAll(
+                optionOrder.subList(args.size(), optionOrder.size()).collect(
+                        { String argName -> keywordArgs.get(argName) }
+                )
+        )
+        add(new ConfigParameter(*args))
+    }
+
+    /**
+     *
+     * @param configMap
+     */
+    void fill(Map<String, Object> configMap) {
+        // Ensure configMap is not null
+        configMap ?= [:]
+
+        // Assign values from map to config
+        configMap.each { name, value -> configure(name, value)}
+        initialize()
+    }
+
+    /**
+     * Configure a parameter of the configuration.
+     *
+     * @param name Name of the parameter
+     * @param value Value of the parameter
+     */
+    void configure(String name, def value) {
+        if (has(name)) {
+            ConfigParameter parameter = vault.get(name)
+            parameter.configure(value)
+        } else {
+            // Log warning and skip the key
+            log.warn("Skipping unknown configuration key: '${name}'")
+        }
+    }
+
+    /**
+     * Initialize the vault.
+     *
+     * @param name Name of the parameter
+     * @param value Value of the parameter
+     */
+    void initialize() {
+        vault.each { String name, ConfigParameter parameter -> parameter.initialize() }
+    }
+
+    /**
+     * Get value of the parameter.
+     *
+     * @param name Name of the parameter
+     * @return The value to the key
+     */
+    def get(String name) {
+        return vault.get(name).get()
+    }
+
+    /**
+     * Evaluate the parameter if it is a function.
+     *
+     * @param name Name of the parameter
+     * @return The evaluated value of the key
+     */
+    <T> T evaluate(String name) {
+        T value = vault.get(name).evaluate()
+        return value
+    }
+
+    /**
+     * Set value of the parameter.
+     *
+     * @param name Name of the parameter
+     * @param value Value to be set to
+     */
+    void set(String name, def value) {
+        ConfigParameter parameter = vault.get(name)
+        parameter.set(value)
+    }
+    /**
+     * Set value of the parameter, when it's null before.
+     *
+     * @param name Name of the parameter
+     * @param value Value to be set to
+     */
+    void setEmpty(String name, def value) {
+        ConfigParameter parameter = vault.get(name)
+        if (parameter.get() == null) {
+            parameter.set(value)
+        }
+    }
+
+    /**
+     * Does the config have this parameter?
+     *
+     * @param name Name of the parameter
+     * @return Whether the property exists in the config instance
+     */
+    Boolean has(String name) {
+        return vault.containsKey(name)
+    }
+
+    /**
+     * Get the current parameter entries.
+     *
+     * @return The entries as a Map
+     */
+    Map<String, Object> getEntries() {
+        return vault.collectEntries { String name, ConfigParameter configParameter ->
+            [name, configParameter.get()]
+        }
+    }
+}

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
@@ -8,6 +8,11 @@ import javax.naming.NameNotFoundException
 class ConfigParameters {
     final private HashMap<String, ConfigEntry> vault
 
+    /**
+    * Constructs the parameter store from a set of ConfigEntry instances. 
+    *
+    * @param configurationParameters Optional set of parameters to preload
+    */
     ConfigParameters(Set<ConfigEntry> configurationParameters=[]) {
         this.vault = configurationParameters.collectEntries { ConfigEntry configParameter ->
             [configParameter.name, configParameter]
@@ -53,7 +58,7 @@ class ConfigParameters {
     }
 
     /**
-     * Configure a parameter of the configuration.
+     * Configure the value of a specific parameter.
      *
      * @param name Name of the parameter
      * @param value Value of the parameter
@@ -139,19 +144,19 @@ class ConfigParameters {
     }
 
     /**
-     * Does the config have this parameter?
+     * Check if a parameter exists by name.
      *
-     * @param name Name of the parameter
-     * @return Whether the property exists in the config instance
+     * @param name Parameter name
+     * @return true if the parameter is defined, false otherwise
      */
     Boolean has(String name) {
         return vault.containsKey(name)
     }
 
     /**
-     * Return the size of the vault.
+     * Returns the number of registered parameters.
      *
-     * @return Current size of the vault
+     * @return Number of entries in the store
      */
     Integer getSize() { return vault.size() }
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
@@ -2,6 +2,8 @@ package nextflow.co2footprint.Config
 
 import groovy.util.logging.Slf4j
 
+import javax.naming.NameNotFoundException
+
 @Slf4j
 class ConfigParameters {
     final private HashMap<String, ConfigEntry> vault
@@ -93,7 +95,13 @@ class ConfigParameters {
      * @return The value to the key
      */
     def get(String name) {
-        return vault.get(name).get()
+        if (has(name)){
+            return vault.get(name).get()
+        } else {
+            String message = "`${name}` is not in configuration."
+            log.error(message)
+            throw new NameNotFoundException(message)
+        }
     }
 
     /**
@@ -154,7 +162,7 @@ class ConfigParameters {
      */
     Map<String, Object> getEntries() {
         return vault.collectEntries { String name, ConfigEntry configParameter ->
-            [name, configParameter.get()]
+            [name, configParameter.evaluate()]
         }
     }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
@@ -38,6 +38,7 @@ class ConfigParameters {
     }
 
     /**
+     * Fill the vault with the entries of the map, if the parameter is given
      *
      * @param configMap
      */
@@ -47,7 +48,6 @@ class ConfigParameters {
 
         // Assign values from map to config
         configMap.each { name, value -> configure(name, value)}
-        initialize()
     }
 
     /**
@@ -69,11 +69,21 @@ class ConfigParameters {
     /**
      * Initialize the vault.
      *
+     * @param overwrite Whether to overwrite the previously set value
+     */
+    void setDefaults(List<Object> args=null, boolean overwrite=false) {
+        vault.each { String name, ConfigEntry parameter -> parameter.setDefault(args, overwrite) }
+    }
+
+    /**
+     * Initialize the vault.
+     *
      * @param name Name of the parameter
      * @param value Value of the parameter
+     * @param overwrite Whether to overwrite the previously set value
      */
-    void initialize() {
-        vault.each { String name, ConfigEntry parameter -> parameter.initialize() }
+    void setDefault(String name, List<Object> args=null, boolean overwrite=false) {
+        vault.get(name).setDefault(args, overwrite)
     }
 
     /**
@@ -129,6 +139,13 @@ class ConfigParameters {
     Boolean has(String name) {
         return vault.containsKey(name)
     }
+
+    /**
+     * Return the size of the vault.
+     *
+     * @return Current size of the vault
+     */
+    Integer getSize() { return vault.size() }
 
     /**
      * Get the current parameter entries.

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Config/ConfigParameters.groovy
@@ -4,12 +4,12 @@ import groovy.util.logging.Slf4j
 
 @Slf4j
 class ConfigParameters {
-    final private HashMap<String, ConfigParameter> vault
+    final private HashMap<String, ConfigEntry> vault
 
-    ConfigParameters(Set<ConfigParameter> configurationParameters=[]) {
-        this.vault = configurationParameters.collectEntries { ConfigParameter configParameter ->
+    ConfigParameters(Set<ConfigEntry> configurationParameters=[]) {
+        this.vault = configurationParameters.collectEntries { ConfigEntry configParameter ->
             [configParameter.name, configParameter]
-        } as HashMap<String, ConfigParameter>
+        } as HashMap<String, ConfigEntry>
     }
 
     /**
@@ -17,7 +17,7 @@ class ConfigParameters {
      *
      * @param parameter Constructed parameter that is added
      */
-    void add(ConfigParameter parameter) {
+    void add(ConfigEntry parameter) {
         this.vault.put(parameter.getName(), parameter)
     }
 
@@ -34,7 +34,7 @@ class ConfigParameters {
                         { String argName -> keywordArgs.get(argName) }
                 )
         )
-        add(new ConfigParameter(*args))
+        add(new ConfigEntry(*args))
     }
 
     /**
@@ -58,7 +58,7 @@ class ConfigParameters {
      */
     void configure(String name, def value) {
         if (has(name)) {
-            ConfigParameter parameter = vault.get(name)
+            ConfigEntry parameter = vault.get(name)
             parameter.configure(value)
         } else {
             // Log warning and skip the key
@@ -73,7 +73,7 @@ class ConfigParameters {
      * @param value Value of the parameter
      */
     void initialize() {
-        vault.each { String name, ConfigParameter parameter -> parameter.initialize() }
+        vault.each { String name, ConfigEntry parameter -> parameter.initialize() }
     }
 
     /**
@@ -104,7 +104,7 @@ class ConfigParameters {
      * @param value Value to be set to
      */
     void set(String name, def value) {
-        ConfigParameter parameter = vault.get(name)
+        ConfigEntry parameter = vault.get(name)
         parameter.set(value)
     }
     /**
@@ -114,7 +114,7 @@ class ConfigParameters {
      * @param value Value to be set to
      */
     void setEmpty(String name, def value) {
-        ConfigParameter parameter = vault.get(name)
+        ConfigEntry parameter = vault.get(name)
         if (parameter.get() == null) {
             parameter.set(value)
         }
@@ -136,7 +136,7 @@ class ConfigParameters {
      * @return The entries as a Map
      */
     Map<String, Object> getEntries() {
-        return vault.collectEntries { String name, ConfigParameter configParameter ->
+        return vault.collectEntries { String name, ConfigEntry configParameter ->
             [name, configParameter.get()]
         }
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
@@ -7,7 +7,7 @@ import java.nio.file.Path
  *
  * Handles file path and overwrite logic for output files (trace, summary, report).
  */
-class CO2FootprintFile {
+class BaseFile {
 
     // Whether to overwrite existing files with the same path
     protected boolean overwrite
@@ -24,7 +24,7 @@ class CO2FootprintFile {
      * @param path Path to the file, or where it is targeted to be written
      * @param overwrite Whether to overwrite existing files with the same path
      */
-    CO2FootprintFile(Path path, boolean overwrite) {
+    BaseFile(Path path, boolean overwrite) {
         this.path = path
         this.overwrite = overwrite
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
@@ -1,5 +1,7 @@
 package nextflow.co2footprint.FileCreators
 
+import nextflow.co2footprint.Config.BaseConfig
+
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -21,10 +23,10 @@ class BaseFile {
     // The actual file object (writer)
     protected PrintWriter file
 
-    static initialize(BaseFileConfig fileConfig){
+    static <T> T initialize(BaseFileConfig fileConfig, Class<T> type=this.class){
         // Break initialization if not enabled
         if(!fileConfig.getEnabled()) { return null }
-        else { return  new BaseFile(fileConfig)}
+        else { return type.newInstance(fileConfig)}
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
@@ -23,10 +23,12 @@ class BaseFile {
     // The actual file object (writer)
     protected PrintWriter file
 
-    static <T> T initialize(BaseFileConfig fileConfig, Class<T> type=this.class){
+
+    static <T> T initialize(BaseFileConfig fileConfig, Class<T> type=BaseFile){
         // Break initialization if not enabled
+        def meta = getMetaClass()
         if(!fileConfig.getEnabled()) { return null }
-        else { return type.newInstance(fileConfig)}
+        else { return type.newInstance(fileConfig) }
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
@@ -1,5 +1,6 @@
 package nextflow.co2footprint.FileCreators
 
+import java.nio.file.Files
 import java.nio.file.Path
 
 /**
@@ -20,6 +21,12 @@ class BaseFile {
     // The actual file object (writer)
     protected PrintWriter file
 
+    static initialize(BaseFileConfig fileConfig){
+        // Break initialization if not enabled
+        if(!fileConfig.getEnabled()) { return null }
+        else { return  new BaseFile(fileConfig)}
+    }
+
     /**
      * Constructor for generic file class.
      *
@@ -39,4 +46,16 @@ class BaseFile {
             fileConfig.getOverwrite()
         )
     }
+
+    /**
+     * Ensures that the directory of the file exists
+     */
+    void ensureParentDirectory() {
+        final Path parent = path.normalize().getParent()
+        if (parent) {
+            Files.createDirectories(parent)
+        }
+    }
+
+    void create() { ensureParentDirectory() }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
@@ -8,6 +8,8 @@ import java.nio.file.Path
  * Handles file path and overwrite logic for output files (trace, summary, report).
  */
 class BaseFile {
+    // Whether to produce a file at all
+    protected  boolean enabled
 
     // Whether to overwrite existing files with the same path
     protected boolean overwrite
@@ -24,8 +26,17 @@ class BaseFile {
      * @param path Path to the file, or where it is targeted to be written
      * @param overwrite Whether to overwrite existing files with the same path
      */
-    BaseFile(Path path, boolean overwrite) {
+    BaseFile(boolean enabled, Path path, boolean overwrite) {
+        this.enabled = enabled
         this.path = path
         this.overwrite = overwrite
+    }
+
+    BaseFile(BaseFileConfig fileConfig) {
+        this(
+            fileConfig.getEnabled(),
+            fileConfig.getPath(),
+            fileConfig.getOverwrite()
+        )
     }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFile.groovy
@@ -26,14 +26,14 @@ class BaseFile {
 
     static <T> T initialize(BaseFileConfig fileConfig, Class<T> type=BaseFile){
         // Break initialization if not enabled
-        def meta = getMetaClass()
         if(!fileConfig.getEnabled()) { return null }
         else { return type.newInstance(fileConfig) }
     }
 
     /**
-     * Constructor for generic file class.
+     * Constructs a BaseFile instance with the specified file path and settings.
      *
+     * @param enabled    Whether the file should be generated or skipped entirely
      * @param path Path to the file, or where it is targeted to be written
      * @param overwrite Whether to overwrite existing files with the same path
      */
@@ -43,6 +43,11 @@ class BaseFile {
         this.overwrite = overwrite
     }
 
+    /**
+     * Constructor for generic file class.
+     *
+     * @param fileConfig Configuration of the file
+     */
     BaseFile(BaseFileConfig fileConfig) {
         this(
             fileConfig.getEnabled(),

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFileConfig.groovy
@@ -6,6 +6,9 @@ import nextflow.trace.TraceHelper
 
 import java.nio.file.Path
 
+/**
+ * A base class for file configurations
+ */
 @Slf4j
 class BaseFileConfig extends BaseConfig {
     // Helper variables
@@ -27,11 +30,16 @@ class BaseFileConfig extends BaseConfig {
                 ['file', makeFile],
                 [returnType: String, allowedTypes: [String, Closure<String>, GString, Path], description: 'Path to file']
         )
+        addParameter(
+                ['overwrite', false],
+                [returnType: Boolean, description: 'Whether to overwrite existing reports']
+        )
     }
 
     Boolean getEnabled() { get('enabled') }
     String getFile() { get('file') }
     Path getPath() { Path.of(get('file') as String) }
+    Boolean getOverwrite() { get('overwrite') }
 
     BaseFileConfig() {
         super()

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFileConfig.groovy
@@ -1,0 +1,42 @@
+package nextflow.co2footprint.FileCreators
+
+import groovy.util.logging.Slf4j
+import nextflow.co2footprint.Config.BaseConfig
+import nextflow.trace.TraceHelper
+
+import java.nio.file.Path
+
+@Slf4j
+class BaseFileConfig extends BaseConfig {
+    // Helper variables
+    protected final String outDirectory = 'pipeline_info'
+    protected final String name = 'co2footprint'
+    protected final String suffix = "_${TraceHelper.launchTimestampFmt()}"
+    protected final String ending = '.txt'
+
+    Closure<String> makeFile= { String outDirectory, name, suffix, ending ->
+        Path.of(outDirectory, "${name}${suffix}${ending}").toString()
+    }
+
+    void initializeParameters() {
+        addParameter(
+                ['enabled', true],
+                [returnType: Boolean, description: 'Whether to create the file']
+        )
+        addParameter(
+                ['file', makeFile],
+                [returnType: String, allowedTypes: [String, Closure<String>, GString, Path], description: 'Path to file']
+        )
+    }
+
+    Boolean getEnabled() { get('enabled') }
+    String getFile() { get('enabled') }
+    Path getPath() { Path.of(get('enabled') as String) }
+
+    BaseFileConfig(Map<String, Object> fileConfigMap) {
+        super()
+        initializeParameters()
+        parameters.fill(fileConfigMap)
+        initialize()
+    }
+}

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFileConfig.groovy
@@ -30,12 +30,12 @@ class BaseFileConfig extends BaseConfig {
     }
 
     Boolean getEnabled() { get('enabled') }
-    String getFile() { get('enabled') }
-    Path getPath() { Path.of(get('enabled') as String) }
+    String getFile() { get('file') }
+    Path getPath() { Path.of(get('file') as String) }
 
-    BaseFileConfig(Map<String, Object> fileConfigMap) {
+    BaseFileConfig() {
         super()
         initializeParameters()
-        parameters.fill(fileConfigMap)
+        setDefaults([outDirectory, name, suffix, ending], false)
     }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/BaseFileConfig.groovy
@@ -37,6 +37,5 @@ class BaseFileConfig extends BaseConfig {
         super()
         initializeParameters()
         parameters.fill(fileConfigMap)
-        initialize()
     }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFile.groovy
@@ -26,7 +26,7 @@ import java.nio.file.Path
  * and writes the final report to disk.
  */
 @Slf4j
-class ReportFile extends BaseFile{
+class ReportFile extends BaseFile {
 
     // Maximum number of tasks to include in the report table
     private int maxTasks
@@ -51,9 +51,9 @@ class ReportFile extends BaseFile{
      * @param overwrite Whether to overwrite existing files
      * @param maxTasks  Maximum number of tasks to include in the report table
      */
-    ReportFile(Path path, boolean overwrite=false, int maxTasks=10_000) {
-        super(path, overwrite)
-        this.maxTasks = maxTasks
+    ReportFile(ReportFileConfig reportFileConfig) {
+        super(reportFileConfig)
+        this.maxTasks = reportFileConfig.getMaxTasks()
     }
 
     /**
@@ -168,8 +168,8 @@ class ReportFile extends BaseFile{
         Map<String,?> all_options = config.collectInputFileOptions() + config.collectOutputFileOptions() + config.collectCO2CalcOptions()
 
         // Render JSON
-        List<Map<String, String>> options = all_options.collect { String name, value ->
-            [option: name, value: (value instanceof Closure) ? '"dynamic"' : value as String]
+        List<Map<String, ?>> options = all_options.collect { String name, value ->
+            [option: name, value: (value instanceof Closure) ? '"dynamic"' : value]
         }
 
         return JsonOutput.toJson(options)

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFile.groovy
@@ -42,7 +42,17 @@ class ReportFile extends BaseFile {
     private Map<TaskId, CO2Record> co2eRecords
 
     // Writer for the HTML file
-    private BufferedWriter writer = TraceHelper.newFileWriter(path, overwrite, 'Report')
+    private BufferedWriter writer
+
+    /**
+     * Initializes a Report File, dependent on whether it is enabled.
+     *
+     * @param reportFileConfig Configuration of the summary
+     * @return A report file.
+     */
+    static ReportFile initialize(ReportFileConfig reportFileConfig) {
+        return initialize(reportFileConfig, ReportFile)
+    }
 
     /**
      * Constructor for the HTML report file.
@@ -54,6 +64,15 @@ class ReportFile extends BaseFile {
     ReportFile(ReportFileConfig reportFileConfig) {
         super(reportFileConfig)
         this.maxTasks = reportFileConfig.getMaxTasks()
+    }
+
+    /**
+     * Create the report file.
+     * If file already exists, it is overwritten or rolled depending on settings.
+     */
+    void create() {
+        super.create()
+        writer = TraceHelper.newFileWriter(path, overwrite, 'Report')
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFile.groovy
@@ -26,7 +26,7 @@ import java.nio.file.Path
  * and writes the final report to disk.
  */
 @Slf4j
-class CO2FootprintReport extends CO2FootprintFile{
+class ReportFile extends BaseFile{
 
     // Maximum number of tasks to include in the report table
     private int maxTasks
@@ -51,7 +51,7 @@ class CO2FootprintReport extends CO2FootprintFile{
      * @param overwrite Whether to overwrite existing files
      * @param maxTasks  Maximum number of tasks to include in the report table
      */
-    CO2FootprintReport(Path path, boolean overwrite=false, int maxTasks=10_000) {
+    ReportFile(Path path, boolean overwrite=false, int maxTasks=10_000) {
         super(path, overwrite)
         this.maxTasks = maxTasks
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFileConfig.groovy
@@ -1,14 +1,29 @@
 package nextflow.co2footprint.FileCreators
 
+/**
+ * A class for report file configurations
+ */
 class ReportFileConfig extends BaseFileConfig {
 
     // Helper variables
     private final String name = "${super.name}_report"
     private final String ending = '.html'
 
-    ReportFileConfig(Map<String, Object> reportConfigMap) {
+    @Override
+    void initializeParameters() {
+        super.initializeParameters()
+        addParameter(
+                ['maxTasks', 10_000],
+                [returnType: Integer, description: 'Number of maximum tasks that are reported']
+        )
+    }
+
+    ReportFileConfig(Map<String, Object> reportConfigMap=[:], String suffix=null) {
         super()
+        suffix ?= this.suffix
         setDefault('file', [outDirectory, name, suffix, ending], true)
         parameters.fill(reportConfigMap)
     }
+
+    Integer getMaxTasks() { get('maxTasks') as Integer }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFileConfig.groovy
@@ -1,0 +1,13 @@
+package nextflow.co2footprint.FileCreators
+
+class ReportFileConfig extends BaseFileConfig {
+
+    // Helper variables
+    private final String name = "${super.name}_report"
+    private final String ending = '.html'
+
+    ReportFileConfig(Map<String, Object> reportConfigMap) {
+        super(reportConfigMap)
+        setDefault('file', [outDirectory, name, suffix, ending], false)
+    }
+}

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/ReportFileConfig.groovy
@@ -7,7 +7,8 @@ class ReportFileConfig extends BaseFileConfig {
     private final String ending = '.html'
 
     ReportFileConfig(Map<String, Object> reportConfigMap) {
-        super(reportConfigMap)
-        setDefault('file', [outDirectory, name, suffix, ending], false)
+        super()
+        setDefault('file', [outDirectory, name, suffix, ending], true)
+        parameters.fill(reportConfigMap)
     }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFile.groovy
@@ -27,6 +27,16 @@ class SummaryFile extends BaseFile {
     Agent<PrintWriter> summaryWriter
 
     /**
+     * Initializes a Summary File, dependent on whether it is enabled.
+     *
+     * @param summaryFileConfig Configuration of the summary
+     * @return A summary file.
+     */
+    static SummaryFile initialize(SummaryFileConfig summaryFileConfig) {
+        return initialize(summaryFileConfig, SummaryFile)
+    }
+
+    /**
      * Constructor for summary file.
      *
      * @param path      Path to the summary file

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFile.groovy
@@ -32,9 +32,16 @@ class SummaryFile extends BaseFile {
      * @param path      Path to the summary file
      * @param overwrite Whether to overwrite existing files
      */
-    SummaryFile(Path path, boolean overwrite) {
-        super(path, overwrite)
-        this.co2eSummaryFile = new PrintWriter(TraceHelper.newFileWriter(path, overwrite, 'co2footprintsummary'))
+    SummaryFile(SummaryFileConfig summaryFileConfig) {
+        super(summaryFileConfig)
+    }
+
+    /**
+     * Create the summary file.
+     * If file already exists, it is overwritten or rolled depending on settings.
+     */
+    void create() {
+        co2eSummaryFile = new PrintWriter(TraceHelper.newFileWriter(path, overwrite, 'co2footprintsummary'))
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFile.groovy
@@ -18,7 +18,7 @@ import java.nio.file.Path
  * to a human-readable summary file at the end of the workflow.
  */
 @Slf4j
-class CO2FootprintSummary extends CO2FootprintFile {
+class SummaryFile extends BaseFile {
 
     // Writer for the summary file
     PrintWriter co2eSummaryFile
@@ -32,7 +32,7 @@ class CO2FootprintSummary extends CO2FootprintFile {
      * @param path      Path to the summary file
      * @param overwrite Whether to overwrite existing files
      */
-    CO2FootprintSummary(Path path, boolean overwrite) {
+    SummaryFile(Path path, boolean overwrite) {
         super(path, overwrite)
         this.co2eSummaryFile = new PrintWriter(TraceHelper.newFileWriter(path, overwrite, 'co2footprintsummary'))
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFile.groovy
@@ -41,6 +41,7 @@ class SummaryFile extends BaseFile {
      * If file already exists, it is overwritten or rolled depending on settings.
      */
     void create() {
+        super.create()
         co2eSummaryFile = new PrintWriter(TraceHelper.newFileWriter(path, overwrite, 'co2footprintsummary'))
     }
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFileConfig.groovy
@@ -1,4 +1,13 @@
 package nextflow.co2footprint.FileCreators
 
-class SummaryFileConfig {
+class SummaryFileConfig extends BaseFileConfig {
+
+    // Helper variables
+    private final String name = "${super.name}_summary"
+
+    SummaryFileConfig(Map<String, Object> summaryConfigMap) {
+        super()
+        setDefault('file', [outDirectory, name, suffix, ending], true)
+        parameters.fill(summaryConfigMap)
+    }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFileConfig.groovy
@@ -1,0 +1,4 @@
+package nextflow.co2footprint.FileCreators
+
+class SummaryFileConfig {
+}

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/SummaryFileConfig.groovy
@@ -1,12 +1,16 @@
 package nextflow.co2footprint.FileCreators
 
+/**
+ * A class for summary file configurations
+ */
 class SummaryFileConfig extends BaseFileConfig {
 
     // Helper variables
     private final String name = "${super.name}_summary"
 
-    SummaryFileConfig(Map<String, Object> summaryConfigMap) {
+    SummaryFileConfig(Map<String, Object> summaryConfigMap=[:], String suffix=null) {
         super()
+        suffix ?= this.suffix
         setDefault('file', [outDirectory, name, suffix, ending], true)
         parameters.fill(summaryConfigMap)
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFile.groovy
@@ -36,6 +36,7 @@ class TraceFile extends BaseFile {
      * If file already exists, it is overwritten or rolled depending on settings.
      */
     void create() {
+        super.create()
         // Create a new trace file writer
         file = new PrintWriter(TraceHelper.newFileWriter(path, overwrite, 'co2footprint'))
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFile.groovy
@@ -6,6 +6,7 @@ import nextflow.co2footprint.Records.CO2Record
 import nextflow.processor.TaskId
 import nextflow.trace.TraceHelper
 import nextflow.trace.TraceRecord
+import org.jsoup.Connection
 
 import java.nio.file.Path
 
@@ -20,6 +21,16 @@ class TraceFile extends BaseFile {
 
     // Agent for thread-safe writing to the trace file
     private Agent<PrintWriter> traceWriter
+
+    /**
+     * Initializes a Trace File, dependent on whether it is enabled.
+     *
+     * @param traceFileConfig Configuration of the summary
+     * @return A trace file.
+     */
+    static TraceFile initialize(TraceFileConfig traceFileConfig) {
+        return initialize(traceFileConfig, TraceFile)
+    }
 
     /**
      * Constructor for the trace file.
@@ -79,14 +90,10 @@ class TraceFile extends BaseFile {
      *
      * @param current Map of TaskId to TraceRecord for unfinished tasks
      */
-    void close(Map<TaskId, TraceRecord> current) {
+    void close() {
         // Wait for agent to finish and flush content
         traceWriter.await()
 
-        // Write remaining records for unfinished tasks
-        current.values().each { record ->
-            file.println("${record.taskId}\t-")
-        }
         file.flush()
         file.close()
     }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFile.groovy
@@ -27,8 +27,8 @@ class TraceFile extends BaseFile {
      * @param path      Path to the trace file
      * @param overwrite Whether to overwrite existing files
      */
-    TraceFile(Path path, boolean overwrite) {
-        super(path, overwrite)
+    TraceFile(TraceFileConfig traceFileConfig) {
+        super(traceFileConfig)
     }
 
     /**

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFile.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFile.groovy
@@ -16,7 +16,7 @@ import java.nio.file.Path
  * Uses an agent for thread-safe writing.
  */
 @Slf4j
-class CO2FootprintTrace extends CO2FootprintFile {
+class TraceFile extends BaseFile {
 
     // Agent for thread-safe writing to the trace file
     private Agent<PrintWriter> traceWriter
@@ -27,7 +27,7 @@ class CO2FootprintTrace extends CO2FootprintFile {
      * @param path      Path to the trace file
      * @param overwrite Whether to overwrite existing files
      */
-    CO2FootprintTrace(Path path, boolean overwrite) {
+    TraceFile(Path path, boolean overwrite) {
         super(path, overwrite)
     }
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFileConfig.groovy
@@ -1,4 +1,13 @@
 package nextflow.co2footprint.FileCreators
 
-class TraceFileConfig {
+class TraceFileConfig extends BaseFileConfig {
+
+    // Helper variables
+    private final String name = "${super.name}_trace"
+
+    TraceFileConfig(Map<String, Object> traceConfigMap) {
+        super()
+        setDefault('file', [outDirectory, name, suffix, ending], true)
+        parameters.fill(traceConfigMap)
+    }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFileConfig.groovy
@@ -1,0 +1,4 @@
+package nextflow.co2footprint.FileCreators
+
+class TraceFileConfig {
+}

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFileConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/TraceFileConfig.groovy
@@ -1,12 +1,16 @@
 package nextflow.co2footprint.FileCreators
 
+/**
+ * A class for trace file configurations
+ */
 class TraceFileConfig extends BaseFileConfig {
 
     // Helper variables
     private final String name = "${super.name}_trace"
 
-    TraceFileConfig(Map<String, Object> traceConfigMap) {
+    TraceFileConfig(Map<String, Object> traceConfigMap=[:], String suffix=null) {
         super()
+        suffix ?= this.suffix
         setDefault('file', [outDirectory, name, suffix, ending], true)
         parameters.fill(traceConfigMap)
     }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintConfigTest.groovy
@@ -96,8 +96,8 @@ class CO2FootprintConfigTest extends Specification {
 
     def 'should log warning and set machineType to null for unknown executor'() {
         given:
-        def configMap = [:]
-        def processMap = [executor: 'notarealexecutor']
+        Map<String, Object> configMap = [:]
+        Map<String, Object> processMap = [executor: 'notarealexecutor']
 
         when:
         CO2FootprintConfig config = new CO2FootprintConfig(configMap, tdp, ci, processMap)

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintObserverTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintObserverTest.groovy
@@ -59,9 +59,9 @@ class CO2FootprintObserverTest extends Specification{
         return Mock(Session) {
             getConfig() >> [
                 co2footprint: [
-                    'traceFile': tracePath,
-                    'summaryFile': summaryPath,
-                    'reportFile': reportPath,
+                    'trace': [file: tracePath as String],
+                    'summary': [file: summaryPath as String],
+                    'report': [file: reportPath as String],
                     'ci': ciValue
                 ]
             ]
@@ -182,12 +182,12 @@ class CO2FootprintObserverTest extends Specification{
         // Mock Session
         Session session = Mock(Session)
         session.getConfig() >> [
-                co2footprint:
-                        [
-                                'traceFile': tracePath,
-                                'summaryFile': summaryPath,
-                                'reportFile': reportPath
-                        ]
+            co2footprint:
+                [
+                    'trace': [file: tracePath as String],
+                    'summary': [file: summaryPath as String],
+                    'report': [file: reportPath as String],
+                ]
         ]
         session.getExecService() >> Executors.newFixedThreadPool(1)
         WorkflowMetadata meta = Mock(WorkflowMetadata)
@@ -237,9 +237,9 @@ class CO2FootprintObserverTest extends Specification{
         fileChecker.runChecks(
                 summaryPath,
                 [
-                        17: "reportFile: ${reportPath}",
-                        18: "summaryFile: ${summaryPath}",
-                        19: "traceFile: ${tracePath}"
+                        17: "report: [enabled:true, file:${reportPath}, overwrite:false, maxTasks:10000]",
+                        18: "summary: [enabled:true, file:${summaryPath}, overwrite:false]",
+                        19: "trace: [enabled:true, file:${tracePath}, overwrite:false]"
                 ]
         )
 
@@ -251,16 +251,16 @@ class CO2FootprintObserverTest extends Specification{
                     "<span id=\"workflow_start\">${time.format('dd-MMM-YYYY HH:mm:ss')}</span>" +
                     " - <span id=\"workflow_complete\">${time.format('dd-MMM-YYYY HH:mm:ss')}</span>",
             1321: '  window.options = [' +
-                    '{"option":"ci","value":"480.0"},'+
+                    '{"option":"ci","value":480.0},'+
                     '{"option":"customCpuTdpFile","value":null},' +
-                    '{"option":"ignoreCpuModel","value":"false"},' +
+                    '{"option":"ignoreCpuModel","value":false},' +
                     '{"option":"location","value":null},' +
                     '{"option":"powerdrawCpuDefault","value":null},' +
-                    '{"option":"powerdrawMem","value":"0.3725"},' +
-                    '{"option":"pue","value":"1.0"},' +
-                    "{\"option\":\"reportFile\",\"value\":\"${reportPath}\"}," +
-                    "{\"option\":\"summaryFile\",\"value\":\"${summaryPath}\"}," +
-                    "{\"option\":\"traceFile\",\"value\":\"${tracePath}\"}];"
+                    '{"option":"powerdrawMem","value":0.3725},' +
+                    '{"option":"pue","value":1.0},' +
+                    "{\"option\":\"report\",\"value\":{\"enabled\":true,\"file\":\"${reportPath}\",\"overwrite\":false,\"maxTasks\":10000}}," +
+                    "{\"option\":\"summary\",\"value\":{\"enabled\":true,\"file\":\"${summaryPath}\",\"overwrite\":false}}," +
+                    "{\"option\":\"trace\",\"value\":{\"enabled\":true,\"file\":\"${tracePath}\",\"overwrite\":false}}];"
             ]
         )
     }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintPluginTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintPluginTest.groovy
@@ -1,0 +1,201 @@
+package nextflow.co2footprint
+
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import nextflow.NextflowMeta
+import nextflow.Session
+import nextflow.executor.NopeExecutor
+import nextflow.processor.TaskHandler
+import nextflow.processor.TaskId
+import nextflow.processor.TaskProcessor
+import nextflow.processor.TaskRun
+import nextflow.script.WorkflowMetadata
+import nextflow.trace.TraceObserver
+import nextflow.trace.TraceRecord
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.OffsetDateTime
+import java.util.concurrent.Executors
+
+class CO2FootprintPluginTest extends Specification{
+    static LoggerContext lc = LoggerFactory.getILoggerFactory() as LoggerContext
+    @Shared
+    Logger logger
+    ListAppender<ILoggingEvent> listAppender = new ListAppender<>()
+
+    @Shared
+    CO2FootprintFactory factory = new CO2FootprintFactory()
+
+    @Shared
+    OffsetDateTime now = OffsetDateTime.now()
+    @Shared
+    TaskRun taskRun
+    @Shared
+    TaskHandler taskHandler
+    @Shared
+    def traceRecord = new TraceRecord()
+
+    def setupSpec() {
+        // Get Logger
+        logger = lc.getLogger('ROOT')
+
+        // Create task
+        taskRun = new TaskRun(id: TaskId.of(111))
+        taskRun.processor = Mock(TaskProcessor)
+        taskHandler = new NopeExecutor().createTaskHandler(taskRun)
+
+        // Make trace record
+        traceRecord.putAll(
+                [
+                        'task_id': '111',
+                        'process': 'observerTestProcess',
+                        'realtime': (1 as Long) * (3600000 as Long), // 1 h
+                        'cpus': 1,
+                        'cpu_model': "Unknown model",
+                        '%cpu': 100.0,
+                        'memory': (7 as Long) * (1024**3 as Long), // 7 GB
+                        'status': 'COMPLETED'
+                ]
+        )
+    }
+
+    def setup() {
+        listAppender.start()
+        logger.addAppender(listAppender)
+    }
+
+    def cleanup() {
+        listAppender.list.clear()
+        logger.detachAndStopAllAppenders()
+        listAppender.stop()
+    }
+
+    /**
+     * Mock a session with given parameters.
+     *
+     * @param config Configuration of the session
+     * @return A Session Mock
+     */
+    Session mockSession(Map config=[:]) {
+        Session session = Mock(Session)
+        session.getExecService() >> Executors.newFixedThreadPool(1)
+        WorkflowMetadata meta = Mock(WorkflowMetadata)
+        meta.scriptId >> 'MOCK'
+        meta.start >> now
+        meta.complete >> now
+        meta.nextflow >> NextflowMeta.instance
+        session.getWorkflowMetadata() >> meta
+        session.config >> config
+
+        return session
+    }
+
+    /**
+     * @return A list with booleans indicating the existence of files
+     */
+    List<Boolean> filesExist(Path tracePath, Path summaryPath,Path reportPath) {
+        return [tracePath, summaryPath, reportPath].collect({ Path path -> path.isFile() })
+    }
+
+    /**
+     * Run all steps to create the out files.
+     *
+     * @return The list of observers
+     */
+    List<TraceObserver> createFiles(Session session) {
+        List<TraceObserver> observers = factory.create(session)
+        CO2FootprintObserver observer = observers[0] as CO2FootprintObserver
+
+        // Run necessary observer steps
+        observer.onFlowCreate(session)
+        observer.onProcessComplete(taskHandler, traceRecord)
+        observer.onFlowComplete()
+
+        return observers
+    }
+
+    def 'Empy configuration'() {
+        when:
+        Session session = mockSession()
+        Collection<TraceObserver> observers = factory.create(session)
+
+        then:
+        observers.size() == 1
+    }
+
+    def 'Creation of all files'() {
+        when:
+        Path tempPath = Files.createTempDirectory('tmpdir')
+        Path tracePath = tempPath.resolve('trace_test.txt')
+        Path summaryPath = tempPath.resolve('summary_test.txt')
+        Path reportPath = tempPath.resolve('report_test.html')
+        Map config = [
+            co2footprint:
+                [
+                    'trace': [file: tracePath as String],
+                    'summary': [file: summaryPath as String],
+                    'report': [file: reportPath as String],
+                ]
+        ]
+        Session session = mockSession(config)
+
+        Collection<TraceObserver> observers = createFiles(session)
+
+        then:
+        observers.size() == 1
+        filesExist(tracePath, summaryPath, reportPath) == [true, true, true]
+    }
+
+    def 'Disabling of a file'() {
+        when:
+        Path tempPath = Files.createTempDirectory('tmpdir')
+        Path tracePath = tempPath.resolve('trace_test.txt')
+        Path summaryPath = tempPath.resolve('summary_test.txt')
+        Path reportPath = tempPath.resolve('report_test.html')
+        Map config = [
+                co2footprint:
+                        [
+                                'trace': [file: tracePath as String],
+                                'summary': [enabled: false, file: summaryPath as String],
+                                'report': [file: reportPath as String],
+                        ]
+        ]
+        Session session = mockSession(config)
+        Collection<TraceObserver> observers = createFiles(session)
+
+        then:
+        observers.size() == 1
+        filesExist(tracePath, summaryPath, reportPath) == [true, false, true]
+    }
+
+    def 'Disabling of all files'() {
+        when:
+        Path tempPath = Files.createTempDirectory('tmpdir')
+        Path tracePath = tempPath.resolve('trace_test.txt')
+        Path summaryPath = tempPath.resolve('summary_test.txt')
+        Path reportPath = tempPath.resolve('report_test.html')
+        Map config = [
+                co2footprint:
+                        [
+                                'trace': [enabled: false, file: tracePath as String],
+                                'summary': [enabled: false, file: summaryPath as String],
+                                'report': [enabled: false, file: reportPath as String],
+                        ]
+        ]
+        Session session = mockSession(config)
+        List<TraceObserver> observers = factory.create(session)
+
+        then:
+        observers.size() == 0
+        filesExist(tracePath, summaryPath, reportPath) == [false, false, false]
+        List app = listAppender.list
+        listAppender.list[-2] as String ==  '[ERROR] All output files are disabled (`enabled=false`). Observer not created.'
+        listAppender.list[-1] as String ==  '[ERROR] No trace observer defined. Exiting plugin.'
+    }
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
@@ -1,0 +1,28 @@
+package nextflow.co2footprint.Config
+
+import spock.lang.Specification
+
+class BaseConfigTest extends Specification{
+    def 'Base configuration class should be correctly configured' () {
+        when:
+        BaseConfig config = new BaseConfig(parameters as Set, configMap, constants)
+
+        then:
+        config.getEntries() == expectedConfigMap
+
+        where:
+        parameters                          || constants    || configMap    || expectedConfigMap
+        [new ConfigParameter('a')]          || [:]          || [a: 1]       || [a: 1]
+        [new ConfigParameter('a')]          || [:]          || [b: 1]       || [a: null]
+        []                                  || [:]          || [a: 1]       || [:]
+    }
+
+    def 'Test evaluation'() {
+        when:
+        BaseConfig config = new BaseConfig([new ConfigParameter('a')] as Set, [a: { -> 1}])
+
+        then:
+        config.evaluate('a') == 1
+    }
+
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
@@ -5,16 +5,16 @@ import spock.lang.Specification
 class BaseConfigTest extends Specification{
     def 'Base configuration class should be correctly configured' () {
         when:
-        BaseConfig config = new BaseConfig(parameters as Set, configMap, constants)
+        BaseConfig config = new BaseConfig(parameters as Set, configMap)
 
         then:
-        config.getEntries() == expectedConfigMap
+        config.parameters.getEntries() == expectedConfigMap
 
         where:
-        parameters                          || constants    || configMap    || expectedConfigMap
-        [new ConfigParameter('a')]          || [:]          || [a: 1]       || [a: 1]
-        [new ConfigParameter('a')]          || [:]          || [b: 1]       || [a: null]
-        []                                  || [:]          || [a: 1]       || [:]
+        parameters                  || configMap    || expectedConfigMap
+        [new ConfigParameter('a')]  || [a: 1]       || [a: 1]
+        [new ConfigParameter('a')]  || [b: 1]       || [a: null]
+        []                          || [a: 1]       || [:]
     }
 
     def 'Test evaluation'() {
@@ -24,5 +24,4 @@ class BaseConfigTest extends Specification{
         then:
         config.evaluate('a') == 1
     }
-
 }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
@@ -24,4 +24,19 @@ class BaseConfigTest extends Specification{
         then:
         config.evaluate('a') == 1
     }
+
+    def 'Nested config' () {
+        when:
+        BaseConfig nestedConfig = new BaseConfig(
+                [new ConfigEntry('a', 0)] as Set,
+                [:]
+        )
+        BaseConfig config = new BaseConfig(
+                [new ConfigEntry('nested', nestedConfig)] as Set,
+                [nested: [a: 1]]
+        )
+
+        then:
+        config.get('nested').get('a') == 1
+    }
 }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
@@ -11,10 +11,10 @@ class BaseConfigTest extends Specification{
         config.parameters.getEntries() == expectedConfigMap
 
         where:
-        parameters                  || configMap    || expectedConfigMap
-        [new ConfigEntry('a')] || [a: 1] || [a: 1]
-        [new ConfigEntry('a')] || [b: 1] || [a: null]
-        []                          || [a: 1]       || [:]
+        parameters             || configMap || expectedConfigMap
+        [new ConfigEntry('a')] || [a: 1]    || [a: 1]
+        [new ConfigEntry('a')] || [b: 1]    || [a: null]
+        []                     || [a: 1]    || [:]
     }
 
     def 'Test evaluation'() {

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/BaseConfigTest.groovy
@@ -12,14 +12,14 @@ class BaseConfigTest extends Specification{
 
         where:
         parameters                  || configMap    || expectedConfigMap
-        [new ConfigParameter('a')]  || [a: 1]       || [a: 1]
-        [new ConfigParameter('a')]  || [b: 1]       || [a: null]
+        [new ConfigEntry('a')] || [a: 1] || [a: 1]
+        [new ConfigEntry('a')] || [b: 1] || [a: null]
         []                          || [a: 1]       || [:]
     }
 
     def 'Test evaluation'() {
         when:
-        BaseConfig config = new BaseConfig([new ConfigParameter('a')] as Set, [a: { -> 1}])
+        BaseConfig config = new BaseConfig([new ConfigEntry('a')] as Set, [a: { -> 1}])
 
         then:
         config.evaluate('a') == 1

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigEntryTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigEntryTest.groovy
@@ -9,7 +9,7 @@ class ConfigEntryTest extends Specification {
 
         then:
         parameter.toMap() == [name: name, value: null, allowedTypes: expAllowedTypes, returnType: expReturnType, description: description]
-        parameter.initialize(initializationArgs)
+        parameter.setDefault(initializationArgs)
         parameter.toMap() == [name: name, value: expValue, allowedTypes: expAllowedTypes, returnType: expReturnType, description: description]
         def evaluated = parameter.evaluate()
         if (evaluated != null) { evaluated in expReturnType }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigEntryTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigEntryTest.groovy
@@ -2,10 +2,10 @@ package nextflow.co2footprint.Config
 
 import spock.lang.Specification
 
-class ConfigParameterTest extends Specification {
+class ConfigEntryTest extends Specification {
     def 'Initialize ConfigParameter correctly' () {
         when:
-        ConfigParameter parameter = new ConfigParameter(name, defaultValue, allowedTypes, returnType, description)
+        ConfigEntry parameter = new ConfigEntry(name, defaultValue, allowedTypes, returnType, description)
 
         then:
         parameter.toMap() == [name: name, value: null, allowedTypes: expAllowedTypes, returnType: expReturnType, description: description]
@@ -26,7 +26,7 @@ class ConfigParameterTest extends Specification {
 
     def 'Evaluate function values correctly'() {
         when:
-        ConfigParameter parameter = new ConfigParameter('a', 1, [Integer, Closure<Integer>])
+        ConfigEntry parameter = new ConfigEntry('a', 1, [Integer, Closure<Integer>])
         parameter.set({ -> 4})
 
         then:

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigParameterTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigParameterTest.groovy
@@ -1,0 +1,35 @@
+package nextflow.co2footprint.Config
+
+import spock.lang.Specification
+
+class ConfigParameterTest extends Specification {
+    def 'Initialize ConfigParameter correctly' () {
+        when:
+        ConfigParameter parameter = new ConfigParameter(name, defaultValue, allowedTypes, returnType, description)
+
+        then:
+        parameter.toMap() == [name: name, value: null, allowedTypes: expAllowedTypes, returnType: expReturnType, description: description]
+        parameter.initialize(initializationArgs)
+        parameter.toMap() == [name: name, value: expValue, allowedTypes: expAllowedTypes, returnType: expReturnType, description: description]
+        def evaluated = parameter.evaluate()
+        if (evaluated != null) { evaluated in expReturnType }
+
+        where:
+        name    || defaultValue                     || allowedTypes || returnType   || description  || initializationArgs   || expValue || expAllowedTypes  || expReturnType
+        'a'     || 1                                || [Integer]    || Integer      || 'a'          || []                   || 1        || [Integer]        || Integer
+        'b'     || '1'                              || [String]     || null         || 'b'          || []                   || '1'      || [String]         || String
+        'c'     || 1 as Long                        || null         || null         || 'long Long'  || []                   || 1l       || [Long]           || Long
+        'd'     || null                             || null         || null         || 'd'          || []                   || null     || [Object]         || Object
+        'e'     || { -> 3 }                         || null         || Integer      || 'd'          || []                   || 3        || [Integer]        || Integer
+        'f'     || {x, y -> "${x}${y}".toString()}  || null         || String       || 'd'          || [1, 3]               || '13'     || [String]         || String
+    }
+
+    def 'Evaluate function values correctly'() {
+        when:
+        ConfigParameter parameter = new ConfigParameter('a', 1, [Integer, Closure<Integer>])
+        parameter.set({ -> 4})
+
+        then:
+        parameter.evaluate() == 4l
+    }
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigParametersTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigParametersTest.groovy
@@ -10,7 +10,7 @@ class ConfigParametersTest extends Specification{
 
         then:
         parameters.getEntries() == [a: null]
-        parameters.initialize()
+        parameters.setDefaults()
         parameters.getEntries() == [a: 1]
     }
 }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigParametersTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/Config/ConfigParametersTest.groovy
@@ -1,0 +1,16 @@
+package nextflow.co2footprint.Config
+
+import spock.lang.Specification
+
+class ConfigParametersTest extends Specification{
+    def 'Test parameter making'() {
+        when:
+        ConfigParameters parameters = new ConfigParameters()
+        parameters.add(['a', 1], [description: 'x'])
+
+        then:
+        parameters.getEntries() == [a: null]
+        parameters.initialize()
+        parameters.getEntries() == [a: 1]
+    }
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/BaseFileConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/BaseFileConfigTest.groovy
@@ -1,0 +1,9 @@
+package nextflow.co2footprint.FileCreators
+
+import spock.lang.Specification
+
+class BaseFileConfigTest extends Specification {
+    def 'Test base class' () {
+        
+    }
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/BaseFileConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/BaseFileConfigTest.groovy
@@ -2,8 +2,17 @@ package nextflow.co2footprint.FileCreators
 
 import spock.lang.Specification
 
+import java.nio.file.Path
+
 class BaseFileConfigTest extends Specification {
     def 'Test base class' () {
-        
+        when:
+        BaseFileConfig config = new BaseFileConfig()
+
+        then:
+        config.getEnabled() == true
+        String start = Path.of('pipeline_info', 'co2footprint_')
+        String regex = "^${start}\\d{8}-\\d*.txt\$"
+        config.getFile().matches(regex)
     }
 }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/FileConfigTests.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/FileConfigTests.groovy
@@ -1,6 +1,0 @@
-package nextflow.co2footprint.FileCreators
-
-import spock.lang.Specification
-
-class FileConfigTests extends Specification {
-}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/FileConfigTests.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/FileConfigTests.groovy
@@ -1,0 +1,6 @@
+package nextflow.co2footprint.FileCreators
+
+import spock.lang.Specification
+
+class FileConfigTests extends Specification {
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileConfigTest.groovy
@@ -1,0 +1,27 @@
+package nextflow.co2footprint.FileCreators
+
+import nextflow.trace.TraceHelper
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Path
+
+class ReportFileConfigTest extends Specification {
+    @Shared
+    String now = TraceHelper.launchTimestampFmt()
+
+    def 'Test initialization of Config' () {
+        when:
+        ReportFileConfig config = new ReportFileConfig(reportConfigMap)
+        config.suffix >> now
+
+        then:
+        config.getEntries() == expectedReportConfigMap
+
+        where:
+        reportConfigMap     || expectedReportConfigMap
+        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_report_${now}.html") as String]
+        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_report_${now}.html") as String]
+        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md']
+    }
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileConfigTest.groovy
@@ -12,16 +12,16 @@ class ReportFileConfigTest extends Specification {
 
     def 'Test initialization of Config' () {
         when:
-        ReportFileConfig config = new ReportFileConfig(reportConfigMap)
-        config.suffix >> now
+        ReportFileConfig config = new ReportFileConfig(reportConfigMap, "_${now}")
 
         then:
         config.getEntries() == expectedReportConfigMap
 
         where:
         reportConfigMap     || expectedReportConfigMap
-        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_report_${now}.html") as String]
-        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_report_${now}.html") as String]
-        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md']
+        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_report_${now}.html") as String, overwrite:false, maxTasks:10000]
+        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_report_${now}.html") as String, overwrite:false, maxTasks:10000]
+        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md', overwrite:false, maxTasks:10000]
+        [file: 'a_file.md', overwrite: true]   || [enabled: true, file: 'a_file.md', overwrite:true, maxTasks:10000]
     }
 }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileTest.groovy
@@ -3,7 +3,6 @@ package nextflow.co2footprint.FileCreators
 import nextflow.Session
 import nextflow.co2footprint.CO2FootprintComputer
 import nextflow.co2footprint.DataContainers.CIDataMatrix
-import nextflow.co2footprint.Records.CO2EquivalencesRecord
 import nextflow.co2footprint.CO2FootprintConfig
 import nextflow.co2footprint.Records.CO2RecordAggregator
 import nextflow.co2footprint.Records.CO2Record
@@ -17,14 +16,14 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.Executors
 
-class CO2FootprintReportTest extends Specification{
+class ReportFileTest extends Specification{
     @Shared
     Path tempPath = Files.createTempDirectory('tmpdir')
 
     @Shared
     Path reportPath = tempPath.resolve('report_test.html')
 
-    static CO2FootprintReport co2FootprintReport
+    static ReportFile co2FootprintReport
 
     def setupSpec() {
         TaskId taskId = new TaskId(111)
@@ -73,7 +72,7 @@ class CO2FootprintReportTest extends Specification{
         CO2RecordAggregator aggregator = new CO2RecordAggregator()
         aggregator.add(traceRecord, co2Record)
 
-        co2FootprintReport = new CO2FootprintReport(reportPath, false, 10_000)
+        co2FootprintReport = new ReportFile(reportPath, false, 10_000)
         co2FootprintReport.addEntries(
                 aggregator.computeProcessStats(),
                 [co2e: 10.0d, energy: 100.0d, co2e_non_cached: 10.0d, energy_non_cached: 100.0d],
@@ -85,7 +84,7 @@ class CO2FootprintReportTest extends Specification{
     def 'Test correct value rendering for totalsJson' () {
         given:
         Path tempPath = Files.createTempDirectory('tmpdir')
-        CO2FootprintReport co2FootprintReport = new CO2FootprintReport(
+        ReportFile co2FootprintReport = new ReportFile(
                 tempPath.resolve('report_test.html')
         )
 

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileTest.groovy
@@ -44,9 +44,9 @@ class ReportFileTest extends Specification{
         Session session = Mock(Session) {
             getConfig() >> [
                     co2footprint: [
-                            'traceFile': tempPath,
-                            'summaryFile': tempPath,
-                            'reportFile': reportPath,
+                            'trace': [file: tempPath],
+                            'summary': [file: tempPath],
+                            'report': [file: reportPath],
                             'ci': 475.0
                     ]
             ]

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/ReportFileTest.groovy
@@ -55,9 +55,9 @@ class ReportFileTest extends Specification{
 
         CO2FootprintConfig config = new CO2FootprintConfig(
                 [
-                    'traceFile': tempPath,
-                    'summaryFile': tempPath,
-                    'reportFile': reportPath,
+                    'trace': new TraceFileConfig([file: tempPath]),
+                    'summary': new SummaryFileConfig([file: tempPath]),
+                    'report': new ReportFileConfig([file: reportPath]),
                     'ci': 475.0
                 ],
                 Mock(TDPDataMatrix),
@@ -72,7 +72,8 @@ class ReportFileTest extends Specification{
         CO2RecordAggregator aggregator = new CO2RecordAggregator()
         aggregator.add(traceRecord, co2Record)
 
-        co2FootprintReport = new ReportFile(reportPath, false, 10_000)
+        ReportFileConfig reportFileConfig = new ReportFileConfig([file: reportPath])
+        co2FootprintReport = new ReportFile(reportFileConfig)
         co2FootprintReport.addEntries(
                 aggregator.computeProcessStats(),
                 [co2e: 10.0d, energy: 100.0d, co2e_non_cached: 10.0d, energy_non_cached: 100.0d],
@@ -84,9 +85,8 @@ class ReportFileTest extends Specification{
     def 'Test correct value rendering for totalsJson' () {
         given:
         Path tempPath = Files.createTempDirectory('tmpdir')
-        ReportFile co2FootprintReport = new ReportFile(
-                tempPath.resolve('report_test.html')
-        )
+        ReportFileConfig reportFileConfig = new ReportFileConfig([file: tempPath.resolve('report_test.html')])
+        ReportFile co2FootprintReport = new ReportFile(reportFileConfig)
 
         when:
         co2FootprintReport.addEntries(
@@ -165,16 +165,16 @@ class ReportFileTest extends Specification{
         then:
         optionsJson ==
                 '[' +
-                    '{"option":"ci","value":"475.0"},'+
+                    '{"option":"ci","value":475.0},'+
                     '{"option":"customCpuTdpFile","value":null},' +
-                    '{"option":"ignoreCpuModel","value":"false"},' +
+                    '{"option":"ignoreCpuModel","value":false},' +
                     '{"option":"location","value":null},' +
                     '{"option":"powerdrawCpuDefault","value":null},' +
-                    '{"option":"powerdrawMem","value":"0.3725"},' +
-                    '{"option":"pue","value":"1.0"},' +
-                    "{\"option\":\"reportFile\",\"value\":\"${reportPath}\"}," +
-                    "{\"option\":\"summaryFile\",\"value\":\"${tempPath}\"}," +
-                    "{\"option\":\"traceFile\",\"value\":\"${tempPath}\"}" +
+                    '{"option":"powerdrawMem","value":0.3725},' +
+                    '{"option":"pue","value":1.0},' +
+                    "{\"option\":\"report\",\"value\":{\"enabled\":true,\"file\":\"${reportPath}\",\"overwrite\":false,\"maxTasks\":10000}}," +
+                    "{\"option\":\"summary\",\"value\":{\"enabled\":true,\"file\":\"${tempPath}\",\"overwrite\":false}}," +
+                    "{\"option\":\"trace\",\"value\":{\"enabled\":true,\"file\":\"${tempPath}\",\"overwrite\":false}}" +
                 ']'
     }
 

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/SummaryFileConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/SummaryFileConfigTest.groovy
@@ -1,0 +1,27 @@
+package nextflow.co2footprint.FileCreators
+
+import nextflow.trace.TraceHelper
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Path
+
+class SummaryFileConfigTest extends  Specification{
+    @Shared
+    String now = TraceHelper.launchTimestampFmt()
+
+    def 'Test initialization of Config' () {
+        when:
+        SummaryFileConfig config = new SummaryFileConfig(summaryConfigMap)
+        config.suffix >> now
+
+        then:
+        config.getEntries() == expectedSummaryConfigMap
+
+        where:
+        summaryConfigMap    || expectedSummaryConfigMap
+        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_summary_${now}.txt") as String]
+        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_summary_${now}.txt") as String]
+        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md']
+    }
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/SummaryFileConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/SummaryFileConfigTest.groovy
@@ -12,16 +12,16 @@ class SummaryFileConfigTest extends  Specification{
 
     def 'Test initialization of Config' () {
         when:
-        SummaryFileConfig config = new SummaryFileConfig(summaryConfigMap)
-        config.suffix >> now
+        SummaryFileConfig config = new SummaryFileConfig(summaryConfigMap, "_${now}")
 
         then:
         config.getEntries() == expectedSummaryConfigMap
 
         where:
         summaryConfigMap    || expectedSummaryConfigMap
-        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_summary_${now}.txt") as String]
-        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_summary_${now}.txt") as String]
-        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md']
+        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_summary_${now}.txt") as String, overwrite:false]
+        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_summary_${now}.txt") as String, overwrite:false]
+        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md', overwrite:false]
+        [file: 'a_file.md', overwrite: true]   || [enabled: true, file: 'a_file.md', overwrite:true]
     }
 }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/TraceFileConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/TraceFileConfigTest.groovy
@@ -1,0 +1,27 @@
+package nextflow.co2footprint.FileCreators
+
+import nextflow.trace.TraceHelper
+import spock.lang.Shared
+import spock.lang.Specification
+
+import java.nio.file.Path
+
+class TraceFileConfigTest extends Specification {
+    @Shared
+    String now = TraceHelper.launchTimestampFmt()
+
+    def 'Test initialization of Config' () {
+        when:
+        TraceFileConfig config = new TraceFileConfig(traceConfigMap)
+        config.suffix >> now
+
+        then:
+        config.getEntries() == expectedTraceConfigMap
+
+        where:
+        traceConfigMap      || expectedTraceConfigMap
+        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_trace_${now}.txt") as String]
+        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_trace_${now}.txt") as String]
+        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md']
+    }
+}

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/TraceFileConfigTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/FileCreators/TraceFileConfigTest.groovy
@@ -12,16 +12,16 @@ class TraceFileConfigTest extends Specification {
 
     def 'Test initialization of Config' () {
         when:
-        TraceFileConfig config = new TraceFileConfig(traceConfigMap)
-        config.suffix >> now
+        TraceFileConfig config = new TraceFileConfig(traceConfigMap, "_${now}")
 
         then:
         config.getEntries() == expectedTraceConfigMap
 
         where:
         traceConfigMap      || expectedTraceConfigMap
-        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_trace_${now}.txt") as String]
-        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_trace_${now}.txt") as String]
-        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md']
+        [:]                 || [enabled: true, file: Path.of('pipeline_info', "co2footprint_trace_${now}.txt") as String, overwrite:false]
+        [enabled: false]    || [enabled: false, file: Path.of('pipeline_info', "co2footprint_trace_${now}.txt") as String, overwrite:false]
+        [file: 'a_file.md'] || [enabled: true, file: 'a_file.md', overwrite:false]
+        [file: 'a_file.md', overwrite: true]   || [enabled: true, file: 'a_file.md', overwrite:true]
     }
 }

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/TestHelper.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/TestHelper.groovy
@@ -308,8 +308,11 @@ class FileChecker {
             this.collectErrors = false
 
             // Copy snapshot
-            Files.copy(path, snapPath, StandardCopyOption.REPLACE_EXISTING)
-
+            try {
+                Files.copy(path, snapPath, StandardCopyOption.REPLACE_EXISTING)
+            } catch (Throwable ignore) {
+                println('No file copied.')
+            }
             // Print info to adopt the changes
             String message =
                 "🔎 The actual error message can be found below under 'Suppressed:'.\n\n" +


### PR DESCRIPTION
## Related Issues
- Files are currently only given with `{traceFile: path/to/file.txt}`, whereas nf-core uses `{trace: [file: path/to/file.txt]}`
- Closes #251 

## 🎯 Motivation
- Align plugin config with nf-core template
- Improve modularity and checking during config creation and calling

## 📋 Summary of changes
- Added `BaseConfig` class for configurations to make repetitive calls upon methods in a config easier
- Added `ConfigEntry` to define entries of our config with desired attributes, including dynamic default initialization, type checking on every value change, nested Configurations setting, initialization indication
- Added config classes for base file type and each specific file
- Removed `CO2Footprint` from naming of nested classes, to avoid redundancy and long names

## 📌 Important details
- Left originally configurable file parameters (`overwrite` & `maxTasks`) configurable for the respective files

## ✅ Checklist
- [x] New functionalities are covered by tests
- [x] Class structure in `test` reflects class structure in `main`
- [x] Documentation reflects changed behaviour
- [x] `README.md` contains information on or reference to new features
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)