### PR TITLE
Fix/CI: CITATION.cff schema, Automated schema checking

### DIFF
--- a/.github/workflows/validate-citations.yml
+++ b/.github/workflows/validate-citations.yml
@@ -1,0 +1,20 @@
+name: "CITATION.cff validation"
+on:
+  push:
+    paths:
+      - CITATION.cff
+  workflow_dispatch:
+
+jobs:
+  Validate-CITATION-cff:
+    runs-on: ubuntu-latest
+    name: Validate CITATION.cff
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate CITATION.cff
+        uses: dieghernan/cff-validator@v4

--- a/.github/workflows/validate-citations.yml
+++ b/.github/workflows/validate-citations.yml
@@ -3,6 +3,9 @@ on:
   push:
     paths:
       - CITATION.cff
+  pull_request:
+    paths:
+      - CITATION.cff
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## Bug Fixes:
 - Logging with Logback < 1.5 (Nextflow < 25) now possible
 - Removed faulty error messages on `customTDPTable` loading
+- Failed uploads to Zenodo
 
 ## Feature
 - Better matching of CPU names by core-specific specification strings like '32-core' optional

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,6 @@
 cff-version: 1.2.0
 message: "If you use or reference this software, please cite it as below"
+type: "software"
 authors:
   - family-names: Carl
     given-names: Josua

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,14 +23,14 @@ authors:
     given-names: Sabrina
     orcid: https://orcid.org/0000-0003-0603-7907
 title: "nf-co2footprint - A nextflow plugin to track CO2e emissions"
-version: 1.0.0
+version: 1.0.0-rc.2
 identifiers:
   - type: doi
     value: 10.5281/zenodo.14622304
 doi: 10.5281/zenodo.14622304
-date-released: 2024-06-10
+date-released: 2025-07-23
 repository-code: "https://github.com/nextflow-io/nf-co2footprint/"
-license: Apache License 2.0
+license: "Apache-2.0"
 keywords:
   - "co2footprint"
   - "co2 footprint"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # nf-co2footprint plugin [WIP]
-
 A Nextflow plugin to estimate the CO₂ footprint of pipeline runs.
+
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16363577.svg)](https://doi.org/10.5281/zenodo.16363577)
+[![Get help on Slack](https://img.shields.io/badge/slack-nextflow%20%23nf--co2footprint-4A154B?labelColor=000000&logo=slack)](https://nextflow.slack.com/channels/nf-co2footprint)
+
 
 ## 📚 Docs 👉🏻 <https://nextflow-io.github.io/nf-co2footprint>
 


### PR DESCRIPTION
## Related Issues
- Resolves failed uploads on Zenodo

## 🎯 Motivation
- Zenodo upload failed because of invalid CITATION.cff file. This should be fixed and prevented in the future.

## 📋 Summary of changes
- Added GitHub action for checking CITATION.cff
- Corrected license

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes