### PR TITLE
Fix: ANSI logging line reset

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Logging/CustomCaptureAppender.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Logging/CustomCaptureAppender.groovy
@@ -5,6 +5,7 @@ import ch.qos.logback.classic.PatternLayout
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.AppenderBase
 
+import nextflow.Global
 import nextflow.Session
 import nextflow.trace.AnsiLogObserver
 import nextflow.util.LoggerHelper
@@ -13,22 +14,11 @@ import nextflow.util.LoggerHelper
  * Mirrors the functionality of nextflow.util.LoggerHelper$CaptureAppender with added customizability
  */
 class CustomCaptureAppender extends AppenderBase<ILoggingEvent> {
-    final Session session
     final PatternLayout layout
 
-    CustomCaptureAppender(Session session, PatternLayout layout) {
+    CustomCaptureAppender(PatternLayout layout) {
         super()
-        this.session = session
         this.layout = layout
-    }
-
-    /**
-     * Start the Appender
-     */
-    @Override
-    void start() {
-        super.start()
-        layout.start()
     }
 
     /**
@@ -38,6 +28,8 @@ class CustomCaptureAppender extends AppenderBase<ILoggingEvent> {
      */
     @Override
     protected void append(ILoggingEvent event) {
+        final Session session = Global.session as Session
+
         try {
             // Format message with Layout
             final String message = layout.doLayout(event)

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Logging/LoggingAdapter.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Logging/LoggingAdapter.groovy
@@ -24,14 +24,10 @@ import java.util.function.Supplier
  */
 @Slf4j
 class LoggingAdapter {
-    Session session
     LoggerContext loggerContext
 
-    LoggingAdapter(
-            Session session=Global.session as Session,
-            LoggerContext loggerContext=LoggerFactory.getILoggerFactory() as LoggerContext
+    LoggingAdapter(LoggerContext loggerContext=LoggerFactory.getILoggerFactory() as LoggerContext
     ) {
-        this.session = session
         this.loggerContext = loggerContext
     }
 
@@ -114,7 +110,7 @@ class LoggingAdapter {
                 appender.start()
 
                 // Replace with custom logger
-                CustomCaptureAppender customCaptureAppender = new CustomCaptureAppender(session, layout)
+                CustomCaptureAppender customCaptureAppender = new CustomCaptureAppender(layout)
                 for (Filter filter : appender.getCopyOfAttachedFiltersList()) {
                     customCaptureAppender.addFilter(filter)
                 }


### PR DESCRIPTION
## Related Issues
- Closes #280 

## 🎯 Motivation
- Have lines always reset on ANSI logging

## 📋 Summary of changes
- Always used current Session during log appending

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)