### PR TITLE
Fix: CI options field for dynamic ci computation in summary

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintConfig.groovy
@@ -227,7 +227,7 @@ class CO2FootprintConfig {
     SortedMap<String, Object> collectCO2CalcOptions() {
         return [
                 "location": location,
-                "ci": ci,
+                "ci": (ci instanceof Closure) ? "dynamic" : ci,
                 "pue": pue,
                 "powerdrawMem": powerdrawMem,
                 "powerdrawCpuDefault": powerdrawCpuDefault,

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/CO2FootprintReport.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreators/CO2FootprintReport.groovy
@@ -167,11 +167,11 @@ class CO2FootprintReport extends CO2FootprintFile{
     protected String renderOptionsJson() {
         Map<String,?> all_options = config.collectInputFileOptions() + config.collectOutputFileOptions() + config.collectCO2CalcOptions()
 
-        // Render JSON
+            // Render JSON
         List<Map<String, String>> options = all_options.collect { String name, value ->
-            [option: name, value: (value instanceof Closure) ? '"dynamic"' : value as String]
+            [option: name, value: value as String]
         }
-
+        
         return JsonOutput.toJson(options)
     }
 


### PR DESCRIPTION
When the Electricity Maps API is used and the carbon intensity (`ci`) value changes over time, the value of `ci` is now recorded as `"dynamic"` in the listed options. Previously, this behavior was only applied in the HTML report, but it now also applies to the summary file.