### PR TITLE
Remove bold formatting in logging messages 

### DIFF
--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/DataContainers/CIDataMatrix.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/DataContainers/CIDataMatrix.groovy
@@ -67,7 +67,7 @@ class CIDataMatrix extends DataMatrix {
         try {
             ci = this.get(targetZone, this.ciColumn)
             log.info(Markers.unique, 
-                    "Using carbon intensity for ${HelperFunctions.bold(targetZone)} from fallback table: ${HelperFunctions.bold(ci.toString())} gCO₂eq/kWh.",
+                    "Using carbon intensity for ${targetZone} from fallback table: ${ci.toString()} gCO₂eq/kWh.",
                     'using-ci-from-table-info'
                     )
         } catch (IllegalArgumentException e) {

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/utils/HelperFunctions.groovy
@@ -13,16 +13,6 @@ import nextflow.trace.TraceRecord
 class HelperFunctions {
 
     /**
-     * Helper function to return bold text
-     *
-     * @param text String to be displayed in bold
-     * @return Emboldened text
-     */
-    static String bold(String text) {
-        return "\033[1m${text}\033[0m"
-    }
-
-    /**
      * Retrieves a value from the trace record by key, or returns a default if the value is missing.
      * If the value is `null`, a warning is logged (once per unique dedupKey).
      *


### PR DESCRIPTION
## Summary
This PR removes bold formatting from log messages, as it was not properly rendered in nextflow.log files and SLURM output files.