### PR TITLE
Refactor: Create report and summary file only `onFlowComplete`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 # Version 1.0.0
 ## Bug Fixes:
 - Wrong memory fallback value (current machine maximum memory) now removed
+- Creation of report and summary file only at end of run
 
 ## Misc:
 - "🔁" now prepended for every `Markers.unique` message

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintObserver.groovy
@@ -114,18 +114,6 @@ class CO2FootprintObserver implements TraceObserver {
     @Override
     boolean enableMetrics() { return true }
 
-    /**
-     * Set the maximum number of tasks to include in the report table.
-     * If exceeded, the table is cut off after the maximum number.
-     *
-     * @param value Maximum number of tasks to include in the report
-     * @return This observer instance
-     */
-    CO2FootprintObserver setMaxTasks(int value) {
-        this.maxTasks = value
-        return this
-    }
-
     // ------ OBSERVER METHODS ------
 
     // ---- WORKFLOW LEVEL ----
@@ -154,10 +142,6 @@ class CO2FootprintObserver implements TraceObserver {
 
         co2eTraceFile = new TraceFileCreator(paths['co2eTrace'], overwrite)
         co2eTraceFile.create()
-
-        co2eSummaryFile = new SummaryFileCreator(paths['co2eSummary'], overwrite)
-
-        co2eReportFile = new ReportFileCreator(paths['co2eReport'], overwrite, maxTasks)
     }
 
     /**
@@ -183,6 +167,11 @@ class CO2FootprintObserver implements TraceObserver {
                 }
             }
         }
+
+        // Make summary and Report File
+        co2eSummaryFile = new SummaryFileCreator(paths['co2eSummary'], overwrite)
+        co2eReportFile = new ReportFileCreator(paths['co2eReport'], overwrite, maxTasks)
+
         // Write report and summary
         co2eSummaryFile.write(totalStats, co2FootprintComputer, config, version)
 

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreation/BaseFileCreator.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreation/BaseFileCreator.groovy
@@ -1,5 +1,6 @@
 package nextflow.co2footprint.FileCreation
 
+import java.nio.file.Files
 import java.nio.file.Path
 
 /**
@@ -15,8 +16,14 @@ class BaseFileCreator {
     // The path where the file is created
     protected Path path
 
+    // The writer
+    protected BufferedWriter writer
+
     // The actual file object (writer)
     protected PrintWriter file
+
+    // Whether this file was created
+    protected boolean created
 
     /**
      * Constructor for generic file class.
@@ -27,5 +34,26 @@ class BaseFileCreator {
     BaseFileCreator(Path path, boolean overwrite) {
         this.path = path
         this.overwrite = overwrite
+    }
+
+    /**
+     * Shared creation functionality.
+     */
+    void create() {
+        // Create the parent directory of a file
+        final Path parent = path.normalize().getParent()
+        if (parent) { Files.createDirectories(parent) }
+
+        this.created = true
+    }
+
+    /**
+     * Close the file writers.
+     */
+    void close() {
+        if (!created) { return }
+
+        file?.close()
+        writer?.close()
     }
 }

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreation/ReportFileCreator.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreation/ReportFileCreator.groovy
@@ -42,7 +42,7 @@ class ReportFileCreator extends BaseFileCreator{
     private Map<TaskId, CO2Record> co2eRecords
 
     // Writer for the HTML file
-    private BufferedWriter writer = TraceHelper.newFileWriter(path, overwrite, 'Report')
+    private BufferedWriter writer
 
     /**
      * Constructor for the HTML report file.
@@ -89,9 +89,20 @@ class ReportFileCreator extends BaseFileCreator{
     }
 
     /**
+     * Create the report file.
+     */
+    void create() {
+        super.create()
+
+        writer = TraceHelper.newFileWriter(path, overwrite, 'Report')
+    }
+
+    /**
      * Write the HTML report to disk.
      */
     void write() {
+        if (!created) { return }
+
         try {
             final String html_output = renderHtml()
             writer.withWriter { w -> w << html_output }
@@ -99,13 +110,6 @@ class ReportFileCreator extends BaseFileCreator{
         catch (Exception e) {
             log.warn("Failed to render CO2e footprint report -- see the log file for details", e)
         }
-    }
-
-    /**
-     * Close the report file writer.
-     */
-    void close() {
-        writer.close()
     }
 
     // ---- RENDERING METHODS -----

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreation/TraceFileCreator.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreation/TraceFileCreator.groovy
@@ -36,8 +36,11 @@ class TraceFileCreator extends BaseFileCreator {
      * If file already exists, it is overwritten or rolled depending on settings.
      */
     void create() {
+        super.create()
+
         // Create a new trace file writer
-        file = new PrintWriter(TraceHelper.newFileWriter(path, overwrite, 'co2footprint'))
+        writer = TraceHelper.newFileWriter(path, overwrite, 'co2footprint')
+        file = new PrintWriter(this.writer)
 
         // Launch the agent for thread-safe writing
         traceWriter = new Agent<PrintWriter>(file)
@@ -63,6 +66,8 @@ class TraceFileCreator extends BaseFileCreator {
      * @param co2Record CO2Record for the task
      */
     void write(TaskId taskId, TraceRecord trace, CO2Record co2Record){
+        if (!created) { return }
+
         List<String> records = co2Record.getReadableEntries()
 
         records = [taskId as String, trace.get('status') as String] + records
@@ -79,6 +84,8 @@ class TraceFileCreator extends BaseFileCreator {
      * @param current Map of TaskId to TraceRecord for unfinished tasks
      */
     void close(Map<TaskId, TraceRecord> current) {
+        if (!created) { return }
+
         // Wait for agent to finish and flush content
         traceWriter.await()
 
@@ -87,6 +94,8 @@ class TraceFileCreator extends BaseFileCreator {
             file.println("${record.taskId}\t-")
         }
         file.flush()
+
         file.close()
+        writer.close()
     }
 }


### PR DESCRIPTION
## Related Issues
- Closes #289 

## 🎯 Motivation
- Keep file creation to minimum, when not needed
- Avoid empty files as exports

## 📋 Summary of changes
- Moved file creation to `onFlowComplete`
- Removed unused method

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)