### PR TITLE
Change CO2 to CO₂ in several files

### DIFF
--- a/docs/co2footprint_calculation.md
+++ b/docs/co2footprint_calculation.md
@@ -1,6 +1,6 @@
 ---
 title: CO₂e calculation
-description: Definition of CO2 footprint
+description: Definition of CO₂ footprint
 hide:
   - toc
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: nf-co2footprint
-description: Nextflow plugin for CO2 footprint estimations
+description: Nextflow plugin for CO₂ footprint estimations
 ---
 
 # nf-co2footprint

--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -75,7 +75,7 @@ $$
 
 ## Cloud computations
 
-While the CO2 footprint calculation works on cloud instances, **nf-co2footprint** can currently not natively support all cloud environments, as cloud-specific values (such as certain CPU models or PUE values) may be missing in our datasets. As a result, calculations may often rely on fallback values.
+While the CO₂ footprint calculation works on cloud instances, **nf-co2footprint** can currently not natively support all cloud environments, as cloud-specific values (such as certain CPU models or PUE values) may be missing in our datasets. As a result, calculations may often rely on fallback values.
 
 !!! info
 

--- a/docs/usage/output.md
+++ b/docs/usage/output.md
@@ -13,8 +13,8 @@ The nf-co2footprint plugin creates three output files:
 - **`summaryFile`** ([sample](../assets/co2footprint_summary_sample.txt))  
   The summary file includes the total CO₂ footprint of the workflow run and the configuration used for the plugin.
   
-- **`reportFile`** ([sample](../assets/co2footprint_report_sample.html))  
-  The HTML report contains information about the carbon footprint of the whole pipeline run as well as plots showing the distributions of the CO₂ emissions for the different processes. The CO2 emissions are separated into newly generated (i.e. from non-cached tasks) and total (including cached tasks). Additionally, it contains a table with the metrics for all individual tasks. The table is limited to 10000 entries by default.
+- **`reportFile`**  
+  The HTML report contains information about the carbon footprint of the whole pipeline run as well as plots showing the distributions of the CO₂ emissions for the different processes. The CO₂ emissions are separated into newly generated (i.e. from non-cached tasks) and total (including cached tasks). Additionally, it contains a table with the metrics for all individual tasks. The table is limited to 10000 entries by default.
 
 !!! note
 

--- a/docs/usage/parameters.md
+++ b/docs/usage/parameters.md
@@ -1,6 +1,6 @@
 ---
 title: Parameters
-description: Customising parameters for the CO2e calculation.
+description: Customising parameters for the CO₂e calculation.
 ---
 
 The following parameters are currently available:

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/CO2FootprintComputer.groovy
@@ -12,7 +12,7 @@ import nextflow.processor.TaskId
 import nextflow.trace.TraceRecord
 
 /**
- * Class for computation of energy usage, CO2 emission, and equivalence metrics.
+ * Class for computation of energy usage, CO₂ emission, and equivalence metrics.
  */
 @Slf4j
 class CO2FootprintComputer {
@@ -35,10 +35,10 @@ class CO2FootprintComputer {
 
 
     /**
-    * Computes the CO2 emissions and energy usage for a given Nextflow task.
+    * Computes the CO₂ emissions and energy usage for a given Nextflow task.
     *
     * Calculation formula (from Green Algorithms, https://doi.org/10.1002/advs.202100707):
-    *   CO2e = t * (n_c * P_c * u_c + n_m * P_m) * PUE * CI * 0.001
+    *   CO₂e = t * (n_c * P_c * u_c + n_m * P_m) * PUE * CI * 0.001
     *     where:
     *       t   = runtime in hours
     *       n_c = number of CPU cores
@@ -47,8 +47,8 @@ class CO2FootprintComputer {
     *       n_m = memory used (GB)
     *       P_m = power draw per GB memory (W)
     *       PUE = power usage effectiveness (datacenter efficiency)
-    *       CI  = carbon intensity (gCO2e/kWh)
-    *   The result is converted to mWh (energy) and mgCO2e (emissions).
+    *       CI  = carbon intensity (gCO₂e/kWh)
+    *   The result is converted to mWh (energy) and mgCO₂e (emissions).
     *
     * Memory assignment logic:
     *   - Uses requested memory if available.
@@ -57,7 +57,7 @@ class CO2FootprintComputer {
     *
     * @param taskID  The Nextflow TaskId for this task.
     * @param trace   The TraceRecord containing task resource usage.
-    * @return        CO2Record with energy consumption, CO2 emissions, and task/resource details.
+    * @return        CO2Record with energy consumption, CO₂ emissions, and task/resource details.
     */
     CO2Record computeTaskCO2footprint(TaskId taskID, TraceRecord trace) {
 
@@ -122,7 +122,7 @@ class CO2FootprintComputer {
          */
         final BigDecimal pue = config.value('pue')    // PUE: power usage effectiveness of datacenter [ratio] (>= 1.0)
 
-        // CI: carbon intensity [gCO2e kWh−1]
+        // CI: carbon intensity [gCO₂e kWh−1]
         final BigDecimal ci = config.value('ci')
 
         // Personal energy mix based carbon intensity
@@ -139,9 +139,9 @@ class CO2FootprintComputer {
         )
 
         /*
-         * Resulting CO2 emission
+         * Resulting CO₂ emission
          */
-        BigDecimal co2e = (energy * ci) // Emissions in CO2 equivalents [g] CO2e
+        BigDecimal co2e = (energy * ci) // Emissions in CO₂ equivalents [g] CO₂e
         BigDecimal co2eMarket = ciMarket ? (energy * ciMarket) : null
 
         return new CO2Record(
@@ -161,11 +161,11 @@ class CO2FootprintComputer {
 
     /**
      * The following values were taken from the Green Algorithms publication (https://doi.org/10.1002/advs.202100707):
-     * The estimated emission of the average passenger car is 175 gCO2e/Km in Europe and 251 gCO2/Km in the US
-     * The estimated emission of flying on a jet aircraft in economy class is between 139 and 244 gCO2e/Km
-     * The estimated sequestered CO2 of a mature tree is ~1 Kg per month (917 g)
-     * A reference flight Paris to London spends 50000 gCO2
-     * @param totalCO2 Total CO2 equivalents that were emitted
+     * The estimated emission of the average passenger car is 175 gCO₂e/Km in Europe and 251 gCO₂/Km in the US
+     * The estimated emission of flying on a jet aircraft in economy class is between 139 and 244 gCO₂e/Km
+     * The estimated sequestered CO₂ of a mature tree is ~1 Kg per month (917 g)
+     * A reference flight Paris to London spends 50000 gCO₂
+     * @param totalCO2 Total CO₂ equivalents that were emitted
      * @return CO2EquivalencesRecord with estimations for sensible comparisons
      */
     static CO2EquivalencesRecord computeCO2footprintEquivalences(Double totalCO2) {

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreation/SummaryFileCreator.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/FileCreation/SummaryFileCreator.groovy
@@ -59,10 +59,10 @@ class SummaryFileCreator extends BaseFileCreator {
         CO2EquivalencesRecord equivalences = co2FootprintComputer.computeCO2footprintEquivalences(totalStats['co2e'])
 
         String outText = """\
-        Total CO2e footprint measures of this workflow run (including cached tasks):
-          CO2e emissions: ${Converter.toReadableUnits(totalStats['co2e'],'', 'g')}
+        Total CO₂e footprint measures of this workflow run (including cached tasks):
+          CO₂e emissions: ${Converter.toReadableUnits(totalStats['co2e'],'', 'g')}
           Energy consumption: ${Converter.toReadableUnits(totalStats['energy'],'k', 'Wh')}
-          CO2e emissions (market): ${totalStats['co2eMarket'] ? Converter.toReadableUnits(totalStats['co2eMarket'], '', 'g') : "-"}
+          CO₂e emissions (market): ${totalStats['co2eMarket'] ? Converter.toReadableUnits(totalStats['co2eMarket'], '', 'g') : "-"}
 
         """.stripIndent()
         List<String> readableEquivalences = equivalences.getReadableEquivalences()

--- a/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Records/CO2EquivalencesRecord.groovy
+++ b/plugins/nf-co2footprint/src/main/nextflow/co2footprint/Records/CO2EquivalencesRecord.groovy
@@ -15,7 +15,7 @@ class CO2EquivalencesRecord {
     private final Double planePercent
 
     /**
-     * Create a record of CO2 Equivalences
+     * Create a record of CO₂ Equivalences
      *
      * @param carKilometers  Distance in km
      * @param treeMonths     Months for a tree
@@ -52,7 +52,7 @@ class CO2EquivalencesRecord {
                 case 'carKilometers' ->
                     outStr = "- ${this.getCarKilometersReadable()} km travelled by car"
                 case 'treeMonths' ->
-                    outStr = "- It takes one tree ${this.getTreeMonthsReadable()} to sequester the equivalent amount of CO2 from the atmosphere"
+                    outStr = "- It takes one tree ${this.getTreeMonthsReadable()} to sequester the equivalent amount of CO₂ from the atmosphere"
                 case 'planePercent' ->
                     if (value < 100) {
                         outStr = "- ${this.getPlanePercentReadable()} of a flight from Paris to London"

--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.css
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.css
@@ -1,5 +1,5 @@
 /*
- * Nextflow CO2e Report Custom CSS
+ * Nextflow CO₂e Report Custom CSS
  */
 
 /* General page style */

--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.html
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.html
@@ -110,7 +110,7 @@ ${ assets_js.join("\n\n\n\n").replaceAll("(?m)^", '    ') }
       </dl>
     </div>
 
-    <!-- TOTAL CO2 cards -->
+    <!-- TOTAL CO₂ cards -->
     <div class="container">
       <h2 id="measures" class="section">CO₂e Footprint Measures</h2>
       <h3 id="measures-total">Total</h3>
@@ -256,7 +256,7 @@ ${ assets_js.join("\n\n\n\n").replaceAll("(?m)^", '    ') }
     </div>
     </div>
 
-    <!-- CO2 footprint measures plot -->
+    <!-- CO₂ footprint measures plot -->
     <div class="container">
       <h3 id="measures-plot">Per process</h3>
       <ul class="nav nav-tabs mb-3" id="co2eplot_tabs" role="tablist">

--- a/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
+++ b/plugins/nf-co2footprint/src/resources/assets/CO2FootprintReportTemplate.js
@@ -72,7 +72,7 @@ $(function() {
     // Extract process statistics
     var stats = window.statsByProcess[processName];
 
-    // Add CO2 Boxplot to plot
+    // Add CO₂ Boxplot to plot
     plot_data_total.push(
       {
         x:processName, y: stats.co2e, name: processName,
@@ -89,7 +89,7 @@ $(function() {
       }
     );
 
-    // Add outline of CO2 emissions from non-cached processes to plot
+    // Add outline of CO₂ emissions from non-cached processes to plot
     plot_data_non_cached.push(
       {
         x:processName, y: stats.co2e_non_cached, name: processName,
@@ -116,7 +116,7 @@ $(function() {
       title: 'Processes',
     },
     yaxis: {
-      title: 'CO2e emission (g)',
+      title: 'CO₂e emission (g)',
       rangemode: 'tozero',
     },
     yaxis2: {

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintComputerTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintComputerTest.groovy
@@ -30,7 +30,7 @@ class CO2FootprintComputerTest extends Specification{
             Paths.get(this.class.getResource('/ci_data/ci_yearly_2024_by_location.csv').toURI())
     )
 
-    // ------ CO2 Calculation ------
+    // ------ CO₂ Calculation ------
 
     def "CO2e calculation for various configurations"() {
         given:

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintFactoryTest.groovy
@@ -31,7 +31,7 @@ import java.nio.file.Path
 /**
  * This class implements various tests.
  *
- * For testing the actual calculations of the CO2e, energy consumption and equivalence values,
+ * For testing the actual calculations of the CO₂e, energy consumption and equivalence values,
  * the results are compared against values retrieved from http://calculator.green-algorithms.org/ v2.2.
  *
  * @author Júlia Mir Pedrol <mirp.julia@gmail.com>, Sabrina Krakau <sabrinakrakau@gmail.com>

--- a/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintObserverTest.groovy
+++ b/plugins/nf-co2footprint/src/test/nextflow/co2footprint/CO2FootprintObserverTest.groovy
@@ -124,7 +124,7 @@ class CO2FootprintObserverTest extends Specification{
         // With TDP = 11.45 (default global)
         // Energy consumption converted to Wh
         round(total_energy*1000) == 14.06
-        // Total CO2 in g (should reflect the CI value you set)
+        // Total CO₂ in g (should reflect the CI value you set)
         round(total_co2) == 6.68
     }
 
@@ -229,7 +229,7 @@ class CO2FootprintObserverTest extends Specification{
         ]
         values == [
             '111', 'COMPLETED', '-', '14.06 Wh', '6.75 g', '-', '480 gCO₂e/kWh', '100 %', '7 GB', '3600s', '1', '11.45 W', 'Unknown model'
-        ] // GA: CO2e is 6.94g with CI of 475 gCO2eq/kWh
+        ] // GA: CO₂e is 6.94g with CI of 475 gCO₂eq/kWh
 
         fileChecker.compareChecksums(tracePath, 'bf2f91768ca03a910e7751645f38cde0')
 

--- a/plugins/nf-co2footprint/src/testResources/file_checks.json
+++ b/plugins/nf-co2footprint/src/testResources/file_checks.json
@@ -1,10 +1,10 @@
 {
   "summary_test.txt": {
-    "checksum": "d43c5d7b3739e4dd1f24c94b5eb6ab20",
+    "checksum": "e38a335eb5dcc8cccbcc76883147bc29",
     "num_lines": 29
   },
   "report_test.html": {
-    "checksum": "1a48d3a9863a856f2878a5671dbefd57",
+    "checksum": "a26a46901e79a2e15364dc8f212eeef9",
     "num_lines": 1139
   }
 }

--- a/plugins/nf-co2footprint/src/testResources/report_test.html
+++ b/plugins/nf-co2footprint/src/testResources/report_test.html
@@ -63,7 +63,7 @@
     
     
     /*
-     * Nextflow CO2e Report Custom CSS
+     * Nextflow CO₂e Report Custom CSS
      */
     
     /* General page style */
@@ -664,7 +664,7 @@
         // Extract process statistics
         var stats = window.statsByProcess[processName];
     
-        // Add CO2 Boxplot to plot
+        // Add CO₂ Boxplot to plot
         plot_data_total.push(
           {
             x:processName, y: stats.co2e, name: processName,
@@ -681,7 +681,7 @@
           }
         );
     
-        // Add outline of CO2 emissions from non-cached processes to plot
+        // Add outline of CO₂ emissions from non-cached processes to plot
         plot_data_non_cached.push(
           {
             x:processName, y: stats.co2e_non_cached, name: processName,
@@ -708,7 +708,7 @@
           title: 'Processes',
         },
         yaxis: {
-          title: 'CO2e emission (g)',
+          title: 'CO₂e emission (g)',
           rangemode: 'tozero',
         },
         yaxis2: {
@@ -856,7 +856,7 @@
 
     // Nextflow report data
     window.data = {"trace":[{"task_id":{"raw":"111","readable":"111"},"process":{"raw":"observerTestProcess","readable":"observerTestProcess"},"realtime":{"raw":3600000,"readable":"1h"},"cpus":{"raw":1,"readable":"1"},"cpu_model":{"raw":"Unknown model","readable":"Unknown model"},"%cpu":{"raw":100.0,"readable":"100.0%"},"memory":{"raw":7,"readable":"7 GB"},"status":{"raw":"COMPLETED","readable":"<span class=\"badge badge-success\">COMPLETED</span>"},"hash":{"raw":null,"readable":"-"},"native_id":{"raw":null,"readable":"-"},"module":{"raw":null,"readable":"-"},"container":{"raw":null,"readable":"-"},"tag":{"raw":null,"readable":"-"},"name":{"raw":null,"readable":"-"},"exit":{"raw":null,"readable":"-"},"submit":{"raw":null,"readable":"-"},"start":{"raw":null,"readable":"-"},"complete":{"raw":null,"readable":"-"},"duration":{"raw":null,"readable":"-"},"%mem":{"raw":null,"readable":"-"},"rss":{"raw":null,"readable":"-"},"vmem":{"raw":null,"readable":"-"},"peak_rss":{"raw":null,"readable":"-"},"peak_vmem":{"raw":null,"readable":"-"},"rchar":{"raw":null,"readable":"-"},"wchar":{"raw":null,"readable":"-"},"syscr":{"raw":null,"readable":"-"},"syscw":{"raw":null,"readable":"-"},"read_bytes":{"raw":null,"readable":"-"},"write_bytes":{"raw":null,"readable":"-"},"attempt":{"raw":null,"readable":"-"},"workdir":{"raw":null,"readable":"-"},"script":{"raw":null,"readable":"-"},"scratch":{"raw":null,"readable":"-"},"queue":{"raw":null,"readable":"-"},"disk":{"raw":null,"readable":"-"},"time":{"raw":1.0,"readable":"3600s"},"env":{"raw":null,"readable":"-"},"error_action":{"raw":null,"readable":"-"},"vol_ctxt":{"raw":null,"readable":"-"},"inv_ctxt":{"raw":null,"readable":"-"},"hostname":{"raw":null,"readable":"-"},"energy":{"raw":0.0140575,"readable":"14.06 Wh"},"co2e":{"raw":6.7476,"readable":"6.75 g"},"co2eMarket":{"raw":null,"readable":"-"},"ci":{"raw":480.0,"readable":"480 gCO\u2082e/kWh"},"powerdrawCPU":{"raw":11.45,"readable":"11.45 W"},"cpuUsage":{"raw":100.0,"readable":"100 %"}}],"summary":{"observerTestProcess":{"co2e":{"all":[6.7476],"total":6.7476,"mean":6.7476,"minLabel":null,"min":6.7476,"q1Label":null,"q1":6.7476,"q2Label":null,"q2":6.7476,"q3Label":null,"q3":6.7476,"maxLabel":null,"max":6.7476},"energy":{"all":[0.0140575],"total":0.0140575,"mean":0.0140575,"minLabel":null,"min":0.0140575,"q1Label":null,"q1":0.0140575,"q2Label":null,"q2":0.0140575,"q3Label":null,"q3":0.0140575,"maxLabel":null,"max":0.0140575},"co2e_non_cached":{"all":[6.7476],"total":6.7476,"mean":6.7476,"minLabel":null,"min":6.7476,"q1Label":null,"q1":6.7476,"q2Label":null,"q2":6.7476,"q3Label":null,"q3":6.7476,"maxLabel":null,"max":6.7476},"energy_non_cached":{"all":[0.0140575],"total":0.0140575,"mean":0.0140575,"minLabel":null,"min":0.0140575,"q1Label":null,"q1":0.0140575,"q2Label":null,"q2":0.0140575,"q3Label":null,"q3":0.0140575,"maxLabel":null,"max":0.0140575},"co2e_market":{},"energy_market":{"all":[0.0140575],"total":0.0140575,"mean":0.0140575,"minLabel":null,"min":0.0140575,"q1Label":null,"q1":0.0140575,"q2Label":null,"q2":0.0140575,"q3Label":null,"q3":0.0140575,"maxLabel":null,"max":0.0140575}}}};
-    window.options = [{"option":"ci","value":"480.0"},{"option":"ciMarket","value":null},{"option":"customCpuTdpFile","value":null},{"option":"ignoreCpuModel","value":"false"},{"option":"location","value":null},{"option":"machineType","value":null},{"option":"powerdrawCpuDefault","value":null},{"option":"powerdrawMem","value":"0.3725"},{"option":"pue","value":"1.0"},{"option":"reportFile","value":"/var/folders/hy/br8lmc9n32ld843gzkx6yfwh0000gp/T/tmpdir2637532584894475629/report_test.html"},{"option":"summaryFile","value":"/var/folders/hy/br8lmc9n32ld843gzkx6yfwh0000gp/T/tmpdir2637532584894475629/summary_test.txt"},{"option":"traceFile","value":"/var/folders/hy/br8lmc9n32ld843gzkx6yfwh0000gp/T/tmpdir2637532584894475629/trace_test.txt"}];
+    window.options = [{"option":"ci","value":"480.0"},{"option":"ciMarket","value":null},{"option":"customCpuTdpFile","value":null},{"option":"ignoreCpuModel","value":"false"},{"option":"location","value":null},{"option":"machineType","value":null},{"option":"powerdrawCpuDefault","value":null},{"option":"powerdrawMem","value":"0.3725"},{"option":"pue","value":"1.0"},{"option":"reportFile","value":"/var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir3849670395256107564/report_test.html"},{"option":"summaryFile","value":"/var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir3849670395256107564/summary_test.txt"},{"option":"traceFile","value":"/var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir3849670395256107564/trace_test.txt"}];
   </script>
 
 </head>
@@ -905,7 +905,7 @@
       <dl>
         <dt>Run times</dt>
         <dd>
-          <span id="workflow_start">22-Aug-2025 12:50:09</span> - <span id="workflow_complete">22-Aug-2025 12:50:09</span>
+          <span id="workflow_start">26-Aug-2025 16:48:27</span> - <span id="workflow_complete">26-Aug-2025 16:48:27</span>
           (<span id="completed_fromnow"></span>duration: <strong>null</strong>)
         </dd>
 
@@ -922,7 +922,7 @@
       </dl>
     </div>
 
-    <!-- TOTAL CO2 cards -->
+    <!-- TOTAL CO₂ cards -->
     <div class="container">
       <h2 id="measures" class="section">CO₂e Footprint Measures</h2>
       <h3 id="measures-total">Total</h3>
@@ -1018,7 +1018,7 @@
     </div>
     </div>
 
-    <!-- CO2 footprint measures plot -->
+    <!-- CO₂ footprint measures plot -->
     <div class="container">
       <h3 id="measures-plot">Per process</h3>
       <ul class="nav nav-tabs mb-3" id="co2eplot_tabs" role="tablist">

--- a/plugins/nf-co2footprint/src/testResources/summary_test.txt
+++ b/plugins/nf-co2footprint/src/testResources/summary_test.txt
@@ -1,11 +1,11 @@
-Total CO2e footprint measures of this workflow run (including cached tasks):
-  CO2e emissions: 6.75 g
+Total CO₂e footprint measures of this workflow run (including cached tasks):
+  CO₂e emissions: 6.75 g
   Energy consumption: 14.06 Wh
-  CO2e emissions (market): -
+  CO₂e emissions (market): -
 
 Which equals:
   - 0.039 km travelled by car
-  - It takes one tree 5h 22min 38.92s to sequester the equivalent amount of CO2 from the atmosphere
+  - It takes one tree 5h 22min 38.92s to sequester the equivalent amount of CO₂ from the atmosphere
   - 0.013 % of a flight from Paris to London
 
 The calculation of these values is based on the carbon footprint computation method developed in the Green Algorithms project:
@@ -24,6 +24,6 @@ nf-co2footprint options:
   powerdrawMem: 0.3725
   pue: 1.0
   customCpuTdpFile: null
-  reportFile: /var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir14913988734438194458/report_test.html
-  summaryFile: /var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir14913988734438194458/summary_test.txt
-  traceFile: /var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir14913988734438194458/trace_test.txt
+  reportFile: /var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir9110394837961778812/report_test.html
+  summaryFile: /var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir9110394837961778812/summary_test.txt
+  traceFile: /var/folders/y4/7wys728x2_b94h_7v_phrl7w0000gn/T/tmpdir9110394837961778812/trace_test.txt


### PR DESCRIPTION
## Summary
This PR updates the notation from "CO2" to "CO₂" (using the Unicode subscript 2) throughout all documentation, code comments, and output files for consistency and scientific accuracy.