### PR TITLE
Exclude link to docs from rendered docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,4 +11,4 @@ description: Nextflow plugin for CO₂ footprint estimations
 
 ==}
 
---8<-- "README.md:6:"
+--8<-- "README.md:9:"


### PR DESCRIPTION
No need to show a link to the docs when I am already there 🙂 