### PR TITLE
Fix/co2record trace fields

### DIFF
--- a/src/main/nextflow/co2footprint/Records/CO2Record.groovy
+++ b/src/main/nextflow/co2footprint/Records/CO2Record.groovy
@@ -41,6 +41,11 @@ class CO2Record extends TraceRecord {
             'cpus', 'powerdrawCPU', 'cpu_model', 'rawEnergyProcessor', 'rawEnergyMemory'
     ]
 
+    // Trace fields to exclude (only the problematic timestamp fields that accumulate)
+    static final Set<String> excludedTraceFields = [
+            'submit', 'start', 'complete'   // Timing fields that accumulate as arrays during execution
+    ] as Set
+
     // Stores non-CO₂ keys from the trace record and store them as traceKeys
     final List<String> traceKeys
 
@@ -58,7 +63,7 @@ class CO2Record extends TraceRecord {
      * @param store Map with all objects to be stores in this CO2Record
      */
     CO2Record(Map<String, Object> store) {
-        traceKeys = store.keySet().findAll({ String key -> key !in co2Keys }) as List<String>
+        traceKeys = store.keySet().findAll({ String key -> key !in co2Keys && key !in excludedTraceFields }) as List<String>
         putAll(store)
     }
 
@@ -84,9 +89,16 @@ class CO2Record extends TraceRecord {
         Double cpuUsage, Long memory, Double time,  Integer cpus, Double powerdrawCPU,
         String cpu_model, Double rawEnergyProcessor, Double rawEnergyMemory
     ) {
-        // Add trace Record values
-        traceKeys = traceRecord.store.keySet() as List<String>
-        putAll(traceRecord.store)
+        // Filter out excluded trace fields before copying
+        Map<String, Object> filteredStore = traceRecord.store.findAll { String key, Object value ->
+            key !in excludedTraceFields
+        } as Map<String, Object>
+        
+        // Track only useful non-CO₂ trace fields
+        traceKeys = filteredStore.keySet().findAll({ String key -> key !in co2Keys }) as List<String>
+        
+        // Add filtered trace fields
+        putAll(filteredStore)
 
         // Define CO2-specific storage
         Map<String, Object> store = new LinkedHashMap<>([


### PR DESCRIPTION
# Fix: Exclude timestamp trace fields from CO2Record plus operations

## Problem

When running workflows, Nextflow logs validation warnings about invalid trace values:

```
DEBUG n.co2footprint.CO2FootprintObserver - Workflow completed -- rendering & saving files
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'submit'; value: '[1771840416539, 1771840432042]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'start'; value: '[1771840416639, 1771840432117]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'complete'; value: '[1771840423986, 1771840437235]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'submit'; value: '[1771840416539, 1771840432042, 1771840438038]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'start'; value: '[1771840416639, 1771840432117, 1771840438135]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'complete'; value: '[1771840423986, 1771840437235, 1771840442260]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'submit'; value: '[1771840416644, 1771840424012]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'start'; value: '[1771840416736, 1771840424093]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'complete'; value: '[1771840432017, 1771840438033]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'submit'; value: '[1771840416644, 1771840424012, 1771840437260]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'start'; value: '[1771840416736, 1771840424093, 1771840437336]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'complete'; value: '[1771840432017, 1771840438033, 1771840447205]'; format: 'null'
DEBUG nextflow.trace.TraceRecord - Not a valid trace value -- field: 'submit'; value: '[1771840416539, 1771840432042, 1771840438038, [1771840416644, 1771840424012, 1771840437260]]'; format: 'null'
```

Notably, the timestamp fields (`submit`, `start`, `complete`) appear as **lists of values** instead of single values, and these lists grow with each workflow aggregation.

**Likely cause**: It appears that when CO2Records are combined via the `plus()` method, all numeric fields are aggregated. The timestamp fields—which should be scalar values—seem to accumulate as lists instead. Nextflow's `TraceRecord` validation expects single timestamp values, so it logs warnings when encountering lists.

The question is: Why are these timestamp fields being aggregated at all? As they are not required for footprint calculation.

---

## Solution: Quick Fix (This PR)

**Exclude timestamp fields from being copied into CO2Record** so they never participate in `plus()` aggregation:

```groovy
static final Set<String> excludedTraceFields = [
    'submit', 'start', 'complete'   // Timing fields that shouldn't be aggregated
] as Set
```

Updated constructor filters these fields before storing:

```groovy
CO2Record(TraceRecord traceRecord, ...) {
    Map<String, Object> filteredStore = traceRecord.store.findAll { String key, Object value ->
        key !in excludedTraceFields
    } as Map<String, Object>
    
    traceKeys = filteredStore.keySet().findAll({ String key -> key !in co2Keys }) as List<String>
    putAll(filteredStore)
    // ... rest of constructor
}
```

---

## Longer-term Solution: Full Refactor (Future PR) see #348 

For a more robust fix, CO2Record should **only include trace record fields actually required for CO₂ computation**.

This would require:
1. Explicitly defining a whitelist of allowed trace fields
2. Updating test data to only expect these fields in CO2Record output
3. Removing timing/performance field handling from `plus()` and related methods

**Benefits:**
- Cleaner separation of concerns (CO2Record = CO₂ data only)
- Prevents similar issues with other fields
- Smaller, more predictable data structures

---
