### PR TITLE
Feature: Align Nextflows's and plugins CPU percentage tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added recommendation for market-based CI usage
 - Single values in process summary plot
 - Numbers that are not in Double format are now accepted for config values
+- Aligned Session tracking with Nextflow's trace tracking
 
 ## Features:
 - Updated the config syntax inline with standard Nextflow style

--- a/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
+++ b/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
@@ -4,15 +4,11 @@ import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.trace.TraceRecord
 import oshi.SystemInfo
-import oshi.driver.linux.proc.CpuStat
 import oshi.driver.linux.proc.ProcessStat
 import oshi.hardware.CentralProcessor
 import oshi.software.os.OSProcess
 import oshi.software.os.OperatingSystem
-import oshi.software.os.linux.LinuxOSProcess
 import oshi.software.os.linux.LinuxOperatingSystem
-import oshi.util.GlobalConfig.PropertyException
-import oshi.util.ProcUtil
 import oshi.util.tuples.Triplet
 
 import java.lang.management.ManagementFactory
@@ -163,13 +159,16 @@ class SessionTraceRecorder {
      * @param pid The PID for which to fetch the stats
      * @return Map of PID stats, or null if the information could not be retrieved (e.g. due to permissions or OS)
      */
-    static Map<ProcessStat.PidStat, Long> getPidStats(Integer pid) {
-        try {
-            Triplet<String, Character, Map<ProcessStat.PidStat, Long>> stats = ProcessStat.getPidStats(pid)
-            return stats.getC()
-        }
-        catch (PropertyException propertyException) {
-            log.trace("Failed to get process stats for PID ${pid}: ${propertyException.message}")
+    Map<ProcessStat.PidStat, Long> getPidStats(Integer pid) {
+        LinuxOperatingSystem
+        if (os instanceof LinuxOperatingSystem) {
+            try {
+                Triplet<String, Character, Map<ProcessStat.PidStat, Long>> stats = ProcessStat.getPidStats(pid)
+                return stats.getC()
+            }
+            catch (Exception e) {
+                log.trace("Failed to get process stats for PID ${pid}: ${e.message}")
+            }
         }
 
         return null

--- a/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
+++ b/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
@@ -4,11 +4,15 @@ import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.trace.TraceRecord
 import oshi.SystemInfo
+import oshi.driver.linux.proc.CpuStat
 import oshi.driver.linux.proc.ProcessStat
 import oshi.hardware.CentralProcessor
 import oshi.software.os.OSProcess
 import oshi.software.os.OperatingSystem
+import oshi.software.os.linux.LinuxOSProcess
+import oshi.software.os.linux.LinuxOperatingSystem
 import oshi.util.GlobalConfig.PropertyException
+import oshi.util.ProcUtil
 import oshi.util.tuples.Triplet
 
 import java.lang.management.ManagementFactory
@@ -35,7 +39,7 @@ class SessionTraceRecorder {
     // Process information
     private int pid
     private OSProcess process
-    private Map<Integer, OSProcess> allProcesses = [(pid): process].asSynchronized()
+    private Map<Integer, OSProcess> allProcesses = [:].asSynchronized()
 
     // Aggregation
     final List<MemorySample> samples = [].asSynchronized() as List<MemorySample>
@@ -47,6 +51,7 @@ class SessionTraceRecorder {
     void start() {
         pid = runtimeBean.pid as int
         process = os.getProcess(pid)
+        allProcesses.put(pid, process)
 
         sessionRecord.putAll(
                 [
@@ -94,23 +99,26 @@ class SessionTraceRecorder {
         List<OSProcess> processList = allProcesses.values() as List<OSProcess>
         processList.each({ OSProcess p -> p.updateAttributes() })
 
-        Map<ProcessStat.PidStat, Long> pidStats = getPidStats()
+        Map<ProcessStat.PidStat, Long> pidStats = getPidStats(pid)
 
         // Determine CPU usage
         Double cpuUsage
         if (pidStats != null) {
-
             Long cpuTime = pidStats.get(ProcessStat.PidStat.UTIME) + pidStats.get(ProcessStat.PidStat.STIME) +
                     pidStats.get(ProcessStat.PidStat.CUTIME) + pidStats.get(ProcessStat.PidStat.CSTIME)
-            log.info("CPU time for PID ${pid}: ${cpuTime} jiffies")
-            Long elapsedTime = processor.getSystemCpuLoadTicks().sum() - pidStats.get(ProcessStat.PidStat.STARTTIME)
-            log.info("End CPU ticks: ${processor.getSystemCpuLoadTicks().sum()} ms")
-            log.info("Elapsed time for PID ${pid}: ${elapsedTime} jiffies")
+            cpuTime = (cpuTime * 1000 / LinuxOperatingSystem.getHz()) as Long // Convert from jiffies to ms
+            log.info("CPU time for PID ${pid}: ${cpuTime} ms")
+            Long elapsedTime = endTimestamp - process.startTime
+            log.info("Start CPU ticks: ${process.startTime}")
+            log.info("System CPU ticks: ${endTimestamp} ms")
+            log.info("Elapsed time for PID ${pid}: ${elapsedTime} ms")
+
             cpuUsage = cpuTime / elapsedTime
             log.info("Calculated CPU usage for PID ${pid}: ${cpuUsage * 100}%")
+            log.info("Other CPU usage: ${processList.collect({ OSProcess p -> p.getProcessCpuLoadCumulative() }).sum() as double}")
         }
         else {
-            cpuUsage = processList.sum({ OSProcess p -> p.getProcessCpuLoadCumulative() }) as double
+            cpuUsage = processList.collect({ OSProcess p -> p.getProcessCpuLoadCumulative() }).sum() as double
         }
 
         sessionRecord.putAll(
@@ -121,20 +129,20 @@ class SessionTraceRecorder {
                         realtime:       runtimeBean.uptime,
                         memory:         Runtime.getRuntime().maxMemory(),
                         '%cpu':         cpuUsage * 100,
-                        read_bytes:     processList.sum({ OSProcess p -> p.bytesRead}) as Long,
-                        write_bytes:    processList.sum({ OSProcess p -> p.bytesWritten}) as Long,
-                        vol_ctxt:       processList.sum({ OSProcess p -> p.minorFaults}) as Long,
-                        inv_ctxt:       processList.sum({ OSProcess p -> p.majorFaults}) as Long,
+                        read_bytes:     processList.collect({ OSProcess p -> p.bytesRead}).sum() as Long,
+                        write_bytes:    processList.collect({ OSProcess p -> p.bytesWritten}).sum() as Long,
+                        vol_ctxt:       processList.collect({ OSProcess p -> p.minorFaults}).sum() as Long,
+                        inv_ctxt:       processList.collect({ OSProcess p -> p.majorFaults}).sum() as Long,
                 ] 
         )
 
         if (samples) {
             sessionRecord.putAll(
                     [
-                            rss:            samples.average({ MemorySample sample -> sample.rssBytes}) as Long,
-                            vmem:           samples.average({ MemorySample sample -> sample.virtualMemoryBytes}) as Long,
-                            peak_rss:       samples.max({ MemorySample sample -> sample.rssBytes}),
-                            peak_vmem:      samples.max({ MemorySample sample -> sample.virtualMemoryBytes}),
+                            rss:            samples.collect({ MemorySample sample -> sample.rssBytes}).average() as Long,
+                            vmem:           samples.collect({ MemorySample sample -> sample.virtualMemoryBytes}).average() as Long,
+                            peak_rss:       samples.collect({ MemorySample sample -> sample.rssBytes}).max() as Long,
+                            peak_vmem:      samples.collect({ MemorySample sample -> sample.virtualMemoryBytes}).max() as Long,
                     ]
             )
         }
@@ -153,9 +161,10 @@ class SessionTraceRecorder {
     /**
      * Attempts to fetch the PID stats for the current process.
      *
+     * @param pid The PID for which to fetch the stats
      * @return Map of PID stats, or null if the information could not be retrieved (e.g. due to permissions or OS)
      */
-    Map<ProcessStat.PidStat, Long> getPidStats() {
+    static Map<ProcessStat.PidStat, Long> getPidStats(Integer pid) {
         try {
             Triplet<String, Character, Map<ProcessStat.PidStat, Long>> stats = ProcessStat.getPidStats(pid)
             return stats.getC()
@@ -186,8 +195,8 @@ class SessionTraceRecorder {
                     timestamp: System.currentTimeMillis(),
 
                     // Memory
-                    rssBytes: activeProcesses.sum({ OSProcess p -> p.residentSetSize}) as Long,
-                    virtualMemoryBytes: activeProcesses.sum({ OSProcess p -> p.virtualSize}) as Long,
+                    rssBytes: activeProcesses.collect({ OSProcess p -> p.residentSetSize}).sum() as Long,
+                    virtualMemoryBytes: activeProcesses.collect({ OSProcess p -> p.virtualSize}).sum() as Long,
             )
 
             samples.add(sample)

--- a/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
+++ b/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
@@ -1,11 +1,15 @@
 package nextflow.co2footprint.Recorders
 
+import groovy.util.logging.Slf4j
 import nextflow.Session
 import nextflow.trace.TraceRecord
 import oshi.SystemInfo
+import oshi.driver.linux.proc.ProcessStat
 import oshi.hardware.CentralProcessor
 import oshi.software.os.OSProcess
 import oshi.software.os.OperatingSystem
+import oshi.util.GlobalConfig.PropertyException
+import oshi.util.tuples.Triplet
 
 import java.lang.management.ManagementFactory
 import java.lang.management.RuntimeMXBean
@@ -16,6 +20,7 @@ import com.sun.management.OperatingSystemMXBean
  * A Recorder of trace values for a Nextflow session, which can be attached after startup
  * to capture timepoints before workflow invocation.
  */
+@Slf4j
 class SessionTraceRecorder {
     // OSHI info handles
     private final RuntimeMXBean          runtimeBean = ManagementFactory.getRuntimeMXBean()
@@ -89,6 +94,25 @@ class SessionTraceRecorder {
         List<OSProcess> processList = allProcesses.values() as List<OSProcess>
         processList.each({ OSProcess p -> p.updateAttributes() })
 
+        Map<ProcessStat.PidStat, Long> pidStats = getPidStats()
+
+        // Determine CPU usage
+        Double cpuUsage
+        if (pidStats != null) {
+
+            Long cpuTime = pidStats.get(ProcessStat.PidStat.UTIME) + pidStats.get(ProcessStat.PidStat.STIME) +
+                    pidStats.get(ProcessStat.PidStat.CUTIME) + pidStats.get(ProcessStat.PidStat.CSTIME)
+            log.info("CPU time for PID ${pid}: ${cpuTime} jiffies")
+            Long elapsedTime = processor.getSystemCpuLoadTicks().sum() - pidStats.get(ProcessStat.PidStat.STARTTIME)
+            log.info("End CPU ticks: ${processor.getSystemCpuLoadTicks().sum()} ms")
+            log.info("Elapsed time for PID ${pid}: ${elapsedTime} jiffies")
+            cpuUsage = cpuTime / elapsedTime
+            log.info("Calculated CPU usage for PID ${pid}: ${cpuUsage * 100}%")
+        }
+        else {
+            cpuUsage = processList.sum({ OSProcess p -> p.getProcessCpuLoadCumulative() }) as double
+        }
+
         sessionRecord.putAll(
                 [
                         status:         'COMPLETED',
@@ -96,7 +120,7 @@ class SessionTraceRecorder {
                         duration:       endTimestamp - (sessionRecord.get('submit') as long),
                         realtime:       runtimeBean.uptime,
                         memory:         Runtime.getRuntime().maxMemory(),
-                        '%cpu':         (processList.sum({ OSProcess p -> p.getProcessCpuLoadCumulative() }) as double) * 100,
+                        '%cpu':         cpuUsage * 100,
                         read_bytes:     processList.sum({ OSProcess p -> p.bytesRead}) as Long,
                         write_bytes:    processList.sum({ OSProcess p -> p.bytesWritten}) as Long,
                         vol_ctxt:       processList.sum({ OSProcess p -> p.minorFaults}) as Long,
@@ -124,6 +148,23 @@ class SessionTraceRecorder {
     void stop() {
         timer.cancel()
         timer.purge()
+    }
+
+    /**
+     * Attempts to fetch the PID stats for the current process.
+     *
+     * @return Map of PID stats, or null if the information could not be retrieved (e.g. due to permissions or OS)
+     */
+    Map<ProcessStat.PidStat, Long> getPidStats() {
+        try {
+            Triplet<String, Character, Map<ProcessStat.PidStat, Long>> stats = ProcessStat.getPidStats(pid)
+            return stats.getC()
+        }
+        catch (PropertyException propertyException) {
+            log.trace("Failed to get process stats for PID ${pid}: ${propertyException.message}")
+        }
+
+        return null
     }
 
     /**

--- a/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
+++ b/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
@@ -109,6 +109,8 @@ class SessionTraceRecorder {
                     rootStats.get(ProcessStat.PidStat.CUTIME) + rootStats.get(ProcessStat.PidStat.CSTIME)
             // Convert from jiffies to ms
             cpuTime = (cpuTime * 1000 / LinuxOperatingSystem.getHz()) as Long
+
+            // Calculate elapsed time since process start
             Long elapsedTime = endTimestamp - process.startTime
 
             cpuUsage = cpuTime / elapsedTime

--- a/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
+++ b/src/main/nextflow/co2footprint/Recorders/SessionTraceRecorder.groovy
@@ -99,23 +99,20 @@ class SessionTraceRecorder {
         List<OSProcess> processList = allProcesses.values() as List<OSProcess>
         processList.each({ OSProcess p -> p.updateAttributes() })
 
-        Map<ProcessStat.PidStat, Long> pidStats = getPidStats(pid)
+        Map<ProcessStat.PidStat, Long> rootStats = getPidStats(pid)
 
         // Determine CPU usage
         Double cpuUsage
-        if (pidStats != null) {
-            Long cpuTime = pidStats.get(ProcessStat.PidStat.UTIME) + pidStats.get(ProcessStat.PidStat.STIME) +
-                    pidStats.get(ProcessStat.PidStat.CUTIME) + pidStats.get(ProcessStat.PidStat.CSTIME)
-            cpuTime = (cpuTime * 1000 / LinuxOperatingSystem.getHz()) as Long // Convert from jiffies to ms
-            log.info("CPU time for PID ${pid}: ${cpuTime} ms")
+        if (rootStats != null) {
+            // Accumulate the running ticks of root including waiting time for children
+            Long cpuTime = rootStats.get(ProcessStat.PidStat.UTIME) + rootStats.get(ProcessStat.PidStat.STIME) +
+                    rootStats.get(ProcessStat.PidStat.CUTIME) + rootStats.get(ProcessStat.PidStat.CSTIME)
+            // Convert from jiffies to ms
+            cpuTime = (cpuTime * 1000 / LinuxOperatingSystem.getHz()) as Long
             Long elapsedTime = endTimestamp - process.startTime
-            log.info("Start CPU ticks: ${process.startTime}")
-            log.info("System CPU ticks: ${endTimestamp} ms")
-            log.info("Elapsed time for PID ${pid}: ${elapsedTime} ms")
 
             cpuUsage = cpuTime / elapsedTime
-            log.info("Calculated CPU usage for PID ${pid}: ${cpuUsage * 100}%")
-            log.info("Other CPU usage: ${processList.collect({ OSProcess p -> p.getProcessCpuLoadCumulative() }).sum() as double}")
+            log.debug("Calculated CPU usage for PID ${pid}: ${cpuUsage}")
         }
         else {
             cpuUsage = processList.collect({ OSProcess p -> p.getProcessCpuLoadCumulative() }).sum() as double


### PR DESCRIPTION
## 🎯 Motivation
- Align session level`%cpu` to Nextflow's trace value tracking

## 📋 Summary of changes
- Used addition of `utime + stime + cutime + cstime` of root process against total system time to determine `%cpu`

## 📌 Important details
- Fixed a bug where the max of memory values was passed on incorrectly
- Excluded starting process from all process list to avoid `null` entry

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)