### PR TITLE
Fix: Added newlines after messages to non-ANSI console logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Never initialized observer called for session emissions on CLI command
 - Included descendant processes into session tracking
 - Total values from workflow in report
+- Missing newlines in non-ANSI logging
 
 ## Misc:
 - Improved the testing of log messages

--- a/src/main/nextflow/co2footprint/Logging/LoggingAdapter.groovy
+++ b/src/main/nextflow/co2footprint/Logging/LoggingAdapter.groovy
@@ -130,7 +130,7 @@ class LoggingAdapter {
                 // Changing encoder to desired layout
                 Encoder encoder = appender.getEncoder() as LayoutWrappingEncoder
                 encoder.stop()
-                encoder.setLayout(layout)
+                encoder.setLayout(defineLayout(pattern + '{}%n'))
                 encoder.start()
 
                 appender.setEncoder(encoder)

--- a/src/main/nextflow/co2footprint/Logging/LoggingAdapter.groovy
+++ b/src/main/nextflow/co2footprint/Logging/LoggingAdapter.groovy
@@ -90,9 +90,6 @@ class LoggingAdapter {
             String pattern='%customHighlight(%level - [nf-co2footprint] %msg)',
             String scope='nextflow.co2footprint'
     ) {
-        // Logback implementation
-        PatternLayout layout = defineLayout(pattern)
-
         // Define logger and add appender
         Logger co2FootprintLogger = loggerContext.getLogger(scope)
 
@@ -113,7 +110,7 @@ class LoggingAdapter {
                 appender.start()
 
                 // Replace with custom logger
-                CustomCaptureAppender customCaptureAppender = new CustomCaptureAppender(session, layout)
+                CustomCaptureAppender customCaptureAppender = new CustomCaptureAppender(session, defineLayout(pattern))
                 for (Filter filter : appender.getCopyOfAttachedFiltersList()) {
                     customCaptureAppender.addFilter(filter)
                 }


### PR DESCRIPTION
## Related Issues
- Closes #364 

## 🎯 Motivation
- Support correct non-ANSI logging

## 📋 Summary of changes
- Added newline char to logging patter

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)