### PR TITLE
Fix post-run metadata, zero-value fallback, CI weighting, and provenance/AWS edge cases

### DIFF
--- a/src/main/nextflow/co2footprint/CO2FootprintCLI.groovy
+++ b/src/main/nextflow/co2footprint/CO2FootprintCLI.groovy
@@ -95,7 +95,7 @@ class CO2FootprintCLI {
             Long currentStart = traceRecord.get('start') as Long
             Long currentComplete = traceRecord.get('complete') as Long
             if (currentStart != null && (start == null || start > currentStart)){ start = currentStart }
-            if (currentComplete != null && (complete == null || complete > currentComplete)){ complete = currentComplete }
+            if (currentComplete != null && (complete == null || complete < currentComplete)){ complete = currentComplete }
         }
         if (start != null){
             metadata.start =  Instant.ofEpochMilli(start).atOffset(ZoneOffset.UTC) ?: null

--- a/src/main/nextflow/co2footprint/CO2FootprintCalculator.groovy
+++ b/src/main/nextflow/co2footprint/CO2FootprintCalculator.groovy
@@ -200,7 +200,7 @@ class CO2FootprintCalculator {
                     dedupKey
             )
         }
-        return value ?: defaultValue
+        return value != null ? value : defaultValue
     }
 
     /**

--- a/src/main/nextflow/co2footprint/CO2FootprintExtension.groovy
+++ b/src/main/nextflow/co2footprint/CO2FootprintExtension.groovy
@@ -97,7 +97,7 @@ class CO2FootprintExtension extends PluginExtensionPoint {
             Long currentStart = traceRecord.get('start') as Long
             Long currentComplete = traceRecord.get('complete') as Long
             if (currentStart != null && (start == null || start > currentStart)){ start = currentStart }
-            if (currentComplete != null && (complete == null || complete > currentComplete)){ complete = currentComplete }
+            if (currentComplete != null && (complete == null || complete < currentComplete)){ complete = currentComplete }
         }
         if (start != null){
             metadata.start =  Instant.ofEpochMilli(start).atOffset(ZoneOffset.UTC) ?: null

--- a/src/main/nextflow/co2footprint/DataContainers/AWSRegionsDataMatrix.groovy
+++ b/src/main/nextflow/co2footprint/DataContainers/AWSRegionsDataMatrix.groovy
@@ -78,7 +78,7 @@ class AWSRegionsDataMatrix extends DataMatrix{
         }
 
         if (region) {
-            region?.trim()
+            region = region.trim()
         } else {
             log.debug('Region could not be fetched via `aws configure get region` command.')
             log.debug('No region found.')

--- a/src/main/nextflow/co2footprint/FileCreation/ProvenanceFileCreator.groovy
+++ b/src/main/nextflow/co2footprint/FileCreation/ProvenanceFileCreator.groovy
@@ -121,7 +121,7 @@ class ProvenanceFileCreator extends BaseFileCreator {
                 }
                 else if (raw.type == 'DateTime') {
                     ldMap[key] = [
-                            '@type': 'schema:DataTime',
+                            '@type': 'schema:DateTime',
                             'value':  Instant.ofEpochMilli(raw.value as Long).toString() ,
                             'unitText': raw.scale + raw.unit
                     ]

--- a/src/main/nextflow/co2footprint/Records/CiRecordCollector.groovy
+++ b/src/main/nextflow/co2footprint/Records/CiRecordCollector.groovy
@@ -132,8 +132,7 @@ class CiRecordCollector {
         }
 
         if (!timestamps) {
-            String message = "Found no timestamps in timeCIs '${timeCIs}' that are " +
-                    "before, during or after the frame of the traceRecord: '${trace}' (${start}-${end})."
+            String message = "No carbon intensity timestamps are available in timeCIs for traceRecord '${trace}' (${start}-${end})."
             log.error(message)
             throw new MissingValueException(message)
         }

--- a/src/main/nextflow/co2footprint/Records/CiRecordCollector.groovy
+++ b/src/main/nextflow/co2footprint/Records/CiRecordCollector.groovy
@@ -122,15 +122,7 @@ class CiRecordCollector {
                 ZoneId.systemDefault()
         )
         Long duration = start.until(end, ChronoUnit.MILLIS)
-
-        // Construct before, during and after key sets
-        Set<LocalDateTime> during = new HashSet<LocalDateTime>(timeCIs.keySet())
-
-        // Remove values from before & after out of the fully covered CI values
-        Set<LocalDateTime> before = during.findAll {LocalDateTime time -> time <= start}
-        during.removeAll(before)
-        Set<LocalDateTime> after = during.findAll {LocalDateTime time -> time >= end}
-        during.removeAll(after)
+        List<LocalDateTime> timestamps = timeCIs.keySet().toList().sort()
 
         /**
          * Return the weight of as the covered fraction of the total duration
@@ -139,39 +131,31 @@ class CiRecordCollector {
             (time1.until(time2, ChronoUnit.MILLIS)) / duration
         }
 
-        // Calculation of average carbon intensity
-        Double averageCi = 0d
-
-        if (during) {
-            if (before) {
-                averageCi += timeCIs.get(before.max()) * getWeight(start, during.min())
-            }
-            else {
-                averageCi += timeCIs.get(during.min()) * getWeight(start, during.min())
-            }
-
-            LocalDateTime last = during.max()
-            during.remove(last)
-            if (during) {
-                // Add weighted average of fully covered duration
-                averageCi += timeCIs.subMap(during).values().average() * getWeight(during.min(), last)
-            }
-
-            // Add overhang
-            averageCi += timeCIs.get(last) * getWeight(last, end)
-        }
-        else if (before) {
-            averageCi += timeCIs.get(before.max()) * getWeight(start, end)
-        }
-        else if (after) {
-            averageCi += timeCIs.get(after.min()) * getWeight(start, end)
-        }
-        else {
+        if (!timestamps) {
             String message = "Found no timestamps in timeCIs '${timeCIs}' that are " +
                     "before, during or after the frame of the traceRecord: '${trace}' (${start}-${end})."
             log.error(message)
             throw new MissingValueException(message)
         }
+
+        LocalDateTime activeTimestamp = timestamps.findAll { LocalDateTime time -> time <= start }.max()
+        if (activeTimestamp == null) {
+            activeTimestamp = timestamps.min()
+        }
+
+        List<LocalDateTime> changesDuringRun = timestamps.findAll { LocalDateTime time -> time > start && time < end }
+
+        // Calculation of average carbon intensity
+        Double averageCi = 0d
+        LocalDateTime segmentStart = start
+
+        changesDuringRun.each { LocalDateTime changeTime ->
+            averageCi += (timeCIs.get(activeTimestamp) as Double) * getWeight(segmentStart, changeTime)
+            segmentStart = changeTime
+            activeTimestamp = changeTime
+        }
+
+        averageCi += (timeCIs.get(activeTimestamp) as Double) * getWeight(segmentStart, end)
 
         return averageCi
     }

--- a/src/test/nextflow/co2footprint/CO2FootprintCalculatorTest.groovy
+++ b/src/test/nextflow/co2footprint/CO2FootprintCalculatorTest.groovy
@@ -169,4 +169,15 @@ class CO2FootprintCalculatorTest extends Specification{
         150.0   | 1    | 2
     }
 
+    def "getTraceOrDefault preserves zero values"() {
+        given:
+        def traceRecord = new TraceRecord()
+        traceRecord.realtime = 0L
+        traceRecord.'%cpu' = 0.0d
+
+        expect:
+        CO2FootprintCalculator.getTraceOrDefault(traceRecord, null, 'realtime', 123L, 'missing-realtime') == 0L
+        CO2FootprintCalculator.getTraceOrDefault(traceRecord, null, '%cpu', 100.0d, 'missing-%cpu') == 0.0d
+    }
+
 }

--- a/src/test/nextflow/co2footprint/FileCreation/ProvenanceFileCreatorTest.groovy
+++ b/src/test/nextflow/co2footprint/FileCreation/ProvenanceFileCreatorTest.groovy
@@ -1,0 +1,41 @@
+package nextflow.co2footprint.FileCreation
+
+import nextflow.co2footprint.Config.ProvenanceFileConfig
+import nextflow.co2footprint.Records.CO2Record
+import nextflow.co2footprint.Records.CO2RecordTree
+import nextflow.trace.TraceRecord
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ProvenanceFileCreatorTest extends Specification {
+    def 'writes DateTime values with schema DateTime type'() {
+        given:
+        Path tempDir = Files.createTempDirectory('provenance-test')
+        Path outputPath = tempDir.resolve('provenance_test.json')
+        ProvenanceFileCreator creator = new ProvenanceFileCreator(
+            new ProvenanceFileConfig([enabled: true, file: outputPath, emissionMetricsOnly: false])
+        )
+
+        TraceRecord traceRecord = new TraceRecord()
+        traceRecord.putAll([
+            task_id: '1',
+            status: 'COMPLETED',
+            name: 'task',
+            submit: 1759849601467L
+        ])
+        CO2Record co2Record = new CO2Record(traceRecord.store)
+        CO2RecordTree recordTree = new CO2RecordTree('task', [level: 'task'], co2Record)
+
+        when:
+        creator.create()
+        creator.write(recordTree)
+        creator.close()
+        String output = outputPath.text
+
+        then:
+        output.contains('"@type": "schema:DateTime"')
+        !output.contains('"@type": "schema:DataTime"')
+    }
+}

--- a/src/test/nextflow/co2footprint/Records/CiRecordCollectorTest.groovy
+++ b/src/test/nextflow/co2footprint/Records/CiRecordCollectorTest.groovy
@@ -53,4 +53,28 @@ class CiRecordCollectorTest extends Specification {
         then:
         weightedCI == 20.0
     }
+
+    def 'Test CI value computation with uneven intervals' () {
+        setup:
+        CiRecordCollector timeCiRecordCollector = new CiRecordCollector(Mock(CO2FootprintConfig))
+        TraceRecord traceRecord = Mock(TraceRecord)
+
+        when:
+        LocalDateTime time_10_00_00 = LocalDateTime.of(2025, 8, 20, 10, 0, 0)
+        LocalDateTime time_10_10_00 = LocalDateTime.of(2025, 8, 20, 10, 10, 0)
+        LocalDateTime time_10_59_00 = LocalDateTime.of(2025, 8, 20, 10, 59, 0)
+        LocalDateTime time_11_00_00 = LocalDateTime.of(2025, 8, 20, 11, 0, 0)
+
+        timeCiRecordCollector.add(new CiRecord(100.0, null, null, null, time_10_00_00))
+        timeCiRecordCollector.add(new CiRecord(500.0, null, null, null, time_10_10_00))
+        timeCiRecordCollector.add(new CiRecord(200.0, null, null, null, time_10_59_00))
+
+        traceRecord.get('start') >> time_10_00_00.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        traceRecord.get('complete') >> time_11_00_00.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+        Double weightedCI = timeCiRecordCollector.getWeightedCI(traceRecord)
+
+        then:
+        Math.round(weightedCI * 100) / 100 == 428.33d
+    }
 }

--- a/src/test/nextflow/co2footprint/Records/CiRecordCollectorTest.groovy
+++ b/src/test/nextflow/co2footprint/Records/CiRecordCollectorTest.groovy
@@ -77,4 +77,27 @@ class CiRecordCollectorTest extends Specification {
         then:
         Math.round(weightedCI * 100) / 100 == 428.33d
     }
+
+    def 'Test CI value computation when first CI value appears after task start' () {
+        setup:
+        CiRecordCollector timeCiRecordCollector = new CiRecordCollector(Mock(CO2FootprintConfig))
+        TraceRecord traceRecord = Mock(TraceRecord)
+
+        when:
+        LocalDateTime time_10_00_00 = LocalDateTime.of(2025, 8, 20, 10, 0, 0)
+        LocalDateTime time_10_05_00 = LocalDateTime.of(2025, 8, 20, 10, 5, 0)
+        LocalDateTime time_10_10_00 = LocalDateTime.of(2025, 8, 20, 10, 10, 0)
+        LocalDateTime time_10_20_00 = LocalDateTime.of(2025, 8, 20, 10, 20, 0)
+
+        timeCiRecordCollector.add(new CiRecord(100.0, null, null, null, time_10_05_00))
+        timeCiRecordCollector.add(new CiRecord(300.0, null, null, null, time_10_10_00))
+
+        traceRecord.get('start') >> time_10_00_00.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        traceRecord.get('complete') >> time_10_20_00.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+        Double weightedCI = timeCiRecordCollector.getWeightedCI(traceRecord)
+
+        then:
+        weightedCI == 200.0d
+    }
 }

--- a/src/testResources/cli/file_checks.json
+++ b/src/testResources/cli/file_checks.json
@@ -8,7 +8,7 @@
     "num_lines": 30
   },
   "report_test.html": {
-    "checksum": "cfe77917897ef2b0fc7c772532fb5df5",
+    "checksum": "ed44d87968505ca53dc1f795e7fda5fe",
     "excluded_lines": [1533, 1587],
     "num_lines": 1813
   },

--- a/src/testResources/cli/report_test.html
+++ b/src/testResources/cli/report_test.html
@@ -1579,12 +1579,12 @@
       <dl>
         <dt>Run times</dt>
         <dd>
-          <span id="workflow_start">07-Oct-2025 15:06:41</span> - <span id="workflow_complete">07-Oct-2025 15:06:41</span>
-          (<span id="completed_fromnow"></span>duration: <strong>445ms</strong>)
+          <span id="workflow_start">07-Oct-2025 15:06:41</span> - <span id="workflow_complete">07-Oct-2025 15:06:42</span>
+          (<span id="completed_fromnow"></span>duration: <strong>1.2s</strong>)
         </dd>
 
         <dt>Nextflow command</dt>
-        <dd><pre class="nfcommand"><code>nextflow plugin nf-co2footprint:postRun --tracePath /Users/josuacarl/Codespace/test/nf-co2footprint-fork/build/resources/test/execution-trace-raw.tsv --config /Users/josuacarl/Codespace/test/nf-co2footprint-fork/build/resources/test/cli/test.config</code></pre></dd>
+        <dd><pre class="nfcommand"><code>nextflow plugin nf-co2footprint:postRun --tracePath /Users/nadja/Documents/co2_footprint/co2_plugin_forks/nf-co2footprint/build/resources/test/execution-trace-raw.tsv --config /Users/nadja/Documents/co2_footprint/co2_plugin_forks/nf-co2footprint/build/resources/test/cli/test.config</code></pre></dd>
       </dl>
 
       <dl>


### PR DESCRIPTION
**Summary**

This PR fixes a handful of correctness bugs in the CO2 calculation and post-run reporting paths.

**What changed**

1. Fixed `getTraceOrDefault()` so real `0` / `0.0` trace values are preserved instead of being treated as missing and replaced by defaults.

2. Fixed workflow metadata generation in both the CLI and extension post-run paths to use the latest task `complete` timestamp, so workflow completion time and duration are calculated correctly.

3. Fixed time-weighted carbon intensity calculation to weight CI values by the duration they cover, which makes results correct for uneven CI sampling intervals.

4. Fixed AWS region normalization so values returned from `aws configure get region` are trimmed before lookup.

5. Fixed provenance JSON-LD output to emit `schema:DateTime` instead of the invalid `schema:DataTime`.

6. Updated and added focused regression tests for:
   - zero-value fallback behavior
   - uneven CI intervals
   - corrected CLI post-run workflow timing
   - provenance `DateTime` serialization

**Why**

These issues could lead to incorrect defaults being applied, wrong workflow duration in post-run reports, biased CI calculations when timestamps are unevenly spaced, failed AWS region matching due to trailing newlines, and invalid JSON-LD typing in provenance output.

**Validation**

Validated with focused Gradle test runs covering:
- `CO2FootprintCalculatorTest`
- `CO2FootprintCLITest`
- `CiRecordCollectorTest`
- `AWSRegionsDataMatrixTests`
- `ProvenanceFileCreatorTest`