### PR TITLE
Feat: Added support for defining trace file separator in CLI run

### DIFF
--- a/docs/usage/extension.md
+++ b/docs/usage/extension.md
@@ -52,7 +52,7 @@ process calculate_CO2 {
 }
 
 workflow {
-  calculate_CO2('<Path_to_your_execution_trace>')
+  calculate_CO2('<Path_to_your_execution_trace>', <config_modifications>, <delimiter>)
 }
 ```
 
@@ -75,3 +75,6 @@ Can be used to calculate the emissions of a trace.
 - **configModifications**:
   Temporarily overrides parameters in the `co2footprint` block of the current Nextflow configuration for a single extension function call. The provided map is merged with the existing configuration and does not affect the overall workflow run. Can be used to adjust settings such as output paths or carbon intensity for post-run estimations. Defaults to [:].  
   Example: `[trace: [file: <Path_to_your_output_trace_file>], ci: <Your_carbon_intensity>]`
+
+- **delimiter**:
+  Delimiter that is used withing execution trace file. Defaults to `'\t'`.

--- a/src/main/nextflow/co2footprint/CO2FootprintCLI.groovy
+++ b/src/main/nextflow/co2footprint/CO2FootprintCLI.groovy
@@ -64,7 +64,7 @@ class CO2FootprintCLI {
         CO2FootprintObserver observer = new CO2FootprintObserver(config, computer)
 
         // Parse the trace file
-        List<TraceRecord> traceRecords = TraceFileParser.parseExecutionTraceFile(tracePath)
+        List<TraceRecord> traceRecords = TraceFileParser.parseExecutionTraceFile(tracePath, parsedArgs.get('delimiter', '\t') as String)
 
         // Create trace file
         observer.traceFile.create()

--- a/src/main/nextflow/co2footprint/CO2FootprintExtension.groovy
+++ b/src/main/nextflow/co2footprint/CO2FootprintExtension.groovy
@@ -60,7 +60,8 @@ class CO2FootprintExtension extends PluginExtensionPoint {
     @Function
     Output calculateCO2(
             Path tracePath,
-            Map<String, Object> configModifications=null
+            Map<String, Object> configModifications=null,
+            String delimiter = '\t'
     ){
         // Define separate observer
         CO2FootprintConfig config = factory.defineConfig(configModifications, session)
@@ -68,7 +69,7 @@ class CO2FootprintExtension extends PluginExtensionPoint {
         CO2FootprintObserver observer = new CO2FootprintObserver(config, calculator)
 
         // Parse the trace file
-        List<TraceRecord> traceRecords = parseTraceFile(tracePath)
+        List<TraceRecord> traceRecords = parseTraceFile(tracePath, delimiter)
 
         // Create trace file
         observer.traceFile.create()

--- a/src/test/nextflow/co2footprint/CO2FootprintCLITest.groovy
+++ b/src/test/nextflow/co2footprint/CO2FootprintCLITest.groovy
@@ -28,7 +28,8 @@ class CO2FootprintCLITest extends  Specification {
         when:
         Map<String, Object> parsedArgs = [
                 tracePath: Path.of(this.class.getResource('/execution-trace-raw.tsv').toURI()).complete().toString(),
-                config: Path.of(this.class.getResource('/cli/test.config').toURI()).complete().toString()
+                config: Path.of(this.class.getResource('/cli/test.config').toURI()).complete().toString(),
+                delimiter: '\t'
         ]
         int exitCode = CO2FootprintCLI.postRun(parsedArgs)
 


### PR DESCRIPTION
## Related Issues
- Closes #377


## 🎯 Motivation
- Give the ability to choose delimiter for execution trace files

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)