### PR TITLE
Fix: zero division crashes when task realtime is 0

### DIFF
--- a/src/main/nextflow/co2footprint/Metrics/Calculator.groovy
+++ b/src/main/nextflow/co2footprint/Metrics/Calculator.groovy
@@ -61,6 +61,8 @@ class Calculator {
         if (values.isEmpty() || weights.isEmpty()) { return null }
 
         Number norm = weights.sum() as Number
+        if (norm == 0) { return null }
+
         Number total = new BigDecimal(0)
         values.eachWithIndex { Object value, Integer index ->
             total += value * weights[index]

--- a/src/main/nextflow/co2footprint/Records/CiRecordCollector.groovy
+++ b/src/main/nextflow/co2footprint/Records/CiRecordCollector.groovy
@@ -124,13 +124,6 @@ class CiRecordCollector {
         Long duration = start.until(end, ChronoUnit.MILLIS)
         List<LocalDateTime> timestamps = timeCIs.keySet().toList().sort()
 
-        /**
-         * Return the weight of as the covered fraction of the total duration
-         */
-        Closure<Double> getWeight = { LocalDateTime time1, LocalDateTime time2 ->
-            (time1.until(time2, ChronoUnit.MILLIS)) / duration
-        }
-
         if (!timestamps) {
             String message = "No carbon intensity timestamps are available in timeCIs for traceRecord '${trace}' (${start}-${end})."
             log.error(message)
@@ -140,6 +133,14 @@ class CiRecordCollector {
         LocalDateTime activeTimestamp = timestamps.findAll { LocalDateTime time -> time <= start }.max()
         if (activeTimestamp == null) {
             activeTimestamp = timestamps.min()
+        }
+
+        if (duration == 0) {
+            return timeCIs.get(activeTimestamp) as Double
+        }
+
+        Closure<Double> getWeight = { LocalDateTime time1, LocalDateTime time2 ->
+            (time1.until(time2, ChronoUnit.MILLIS)) / duration
         }
 
         List<LocalDateTime> changesDuringRun = timestamps.findAll { LocalDateTime time -> time > start && time < end }

--- a/src/test/nextflow/co2footprint/Metrics/CalculatorTest.groovy
+++ b/src/test/nextflow/co2footprint/Metrics/CalculatorTest.groovy
@@ -16,5 +16,7 @@ class CalculatorTest extends Specification {
         [null, 2]       || [null, 2]        || 2.0
         [null, null]    || [null, null]     || null
         [1.0, 1.0, 1.0] || [0.1, 0.5, 0.4]  || 1.0
+        [50.0, 80.0]    || [0, 0]           || null
+        [50.0]          || [0]              || null
     }
 }


### PR DESCRIPTION
When a Nextflow task reports `realtime = 0`, two separate code paths crash with `ArithmeticException`:

- `Calculator.weightedAverage()` divides by the sum of weights, which is 0 when all realtime values are 0 — added a norm == 0 guard returning null early.
- `CiRecordCollector.getWeightedCI() `divides by duration (= complete - start), which is 0 when both timestamps are identical — added an early return of the CI at the start timestamp.