### PR TITLE
Deduplicate log warnings across all CO2 estimation entry points

### DIFF
--- a/src/main/nextflow/co2footprint/CO2FootprintCLI.groovy
+++ b/src/main/nextflow/co2footprint/CO2FootprintCLI.groovy
@@ -23,6 +23,10 @@ class CO2FootprintCLI {
      * @return Exit code of the CLI execution, 0 if successful
      */
     static int postRun(Map<String, Object> parsedArgs) {
+        // Ensure duplicate warnings (e.g. unknown CPU model) are deduplicated,
+        // regardless of whether this was reached via CO2FootprintPlugin.exec() or called directly.
+        CO2FootprintFactory.adaptLogging()
+
         // Define trace path
         Path tracePath = parsedArgs.containsKey('tracePath') ? Path.of(parsedArgs.get('tracePath') as String) : null
         Path provenancePath = parsedArgs.containsKey('provenancePath') ? Path.of(parsedArgs.get('provenancePath') as String) : null

--- a/src/main/nextflow/co2footprint/CO2FootprintExtension.groovy
+++ b/src/main/nextflow/co2footprint/CO2FootprintExtension.groovy
@@ -37,6 +37,7 @@ class CO2FootprintExtension extends PluginExtensionPoint {
     void init(Session session) {
         factory = new CO2FootprintFactory()
         this.session = session
+        CO2FootprintFactory.adaptLogging()
     }
 
     /**

--- a/src/main/nextflow/co2footprint/Logging/LoggingAdapter.groovy
+++ b/src/main/nextflow/co2footprint/Logging/LoggingAdapter.groovy
@@ -137,9 +137,15 @@ class LoggingAdapter {
     }
 
     /**
-     * Adds a DeduplicateMarkerFilter to filter out all Markers.unique markers
+     * Adds a DeduplicateMarkerFilter to filter out all Markers.unique markers.
+     * Does nothing if a DeduplicateMarkerFilter is already registered on the context,
+     * so it is safe to call this repeatedly (e.g. from multiple entry points).
      */
     void addUniqueMarkerFilter() {
+        boolean alreadyRegistered = loggerContext.getTurboFilterList().any { it instanceof DeduplicateMarkerFilter }
+        if (alreadyRegistered) {
+            return
+        }
         final TurboFilter deduplicateMarkerFilter = new DeduplicateMarkerFilter(
                 [Markers.unique, Markers.silentUnique]
         )   // Define DeduplicateMarkerFilter


### PR DESCRIPTION
## Summary
- `CO2FootprintCLI.postRun()` and the `calculateCO2`/`parseTraceFile` function extension never registered the log deduplication filter, so warnings like "unknown CPU model" were logged in full for every task instead of collapsing to one WARN + DEBUG `[DUPLICATE]`s, as happens in the live observer path.
- Both entry points now call `adaptLogging()`, which is now idempotent so it's safe to call from multiple places.

Before it looked like this: 
<img width="995" height="258" alt="Screenshot 2026-07-09 at 13 25 58" src="https://github.com/user-attachments/assets/94fa6813-fc44-43b9-b337-27ba9449b0f4" />
