### PR TITLE
Fix: Additional optional co2footprint during summarization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - 
 
 ## Bug Fixes:
--
+- Support for empty runs
 
 ## Misc:
 - 

--- a/src/main/nextflow/co2footprint/Records/CO2RecordTree.groovy
+++ b/src/main/nextflow/co2footprint/Records/CO2RecordTree.groovy
@@ -76,7 +76,7 @@ class CO2RecordTree {
             co2Record = children.collect({ CO2RecordTree child -> child.co2Record }).sum() as CO2Record
         }
         
-        if(co2Record.get('name') == null) { co2Record.put('name', name) }
+        if(co2Record?.get('name') == null) { co2Record?.put('name', name) }
 
         return this
     }


### PR DESCRIPTION
## 🎯 Motivation
- Support empty runs (i.e. for config tests)

## 📋 Summary of changes
- Made `co2footprint` optional during tree summarization step

## ✅ Checklist
- [x] `CHANGELOG.md` is updated with a note on your changes
- [x] Ensure all tests pass (`.\gradlew check`)